### PR TITLE
update __repr__ for BetaNoisePetriNetODESystem

### DIFF
--- a/src/pyciemss/PetriNetODE/base.py
+++ b/src/pyciemss/PetriNetODE/base.py
@@ -388,6 +388,11 @@ class BetaNoisePetriNetODESystem(MiraPetriNetODESystem):
         super().__init__(G)
         self.register_buffer("pseudocount", torch.as_tensor(pseudocount))
 
+    def __repr__(self):
+        par_string = [f"({get_name(p)}={p.value})" for p in self.G.parameters.values()].join(", ")
+        count_string = f"pseudocount={self.pseudocount}"
+        return f"{self.__class__.__name__}({par_string}, {count_string})"
+
     @pyro.nn.pyro_method
     def observation_model(self, solution: Solution, var_name: str) -> None:
         mu = solution[var_name]


### PR DESCRIPTION
Addresses https://github.com/ciemss/pyciemss/issues/98

This code
```python
import os
import numpy as np
import pyciemss

from pyciemss.PetriNetODE.interfaces import load_petri_model, setup_model, sample, calibrate
PYCIEMSS_PATH = ".."
STARTERKIT_PATH = os.path.join(PYCIEMSS_PATH, "test/models/starter_kit_examples/")
MIRA_PATH = os.path.join(PYCIEMSS_PATH, "test/models/evaluation_examples/")

filename = "CHIME-SIR/model_petri.json"
filename = os.path.join(STARTERKIT_PATH, filename)

model = load_petri_model(filename, add_uncertainty=True)
model = setup_model(model, start_time=0.0, start_state=dict(S=0.99, I=0.01, R=0.0))
model
```
used to print
```python
BetaNoisePetriNetODESystem()
```

Now, it instead prints
```python
BetaNoisePetriNetODESystem((a_beta=Uniform(low: 0.8999999761581421, high: 1.100000023841858)), (a_gamma=Uniform(low: 0.8999999761581421, high: 1.100000023841858)), pseudocount=1)
```

This is better, but still not ideal. But I think further improvement would require changing how Pyro displays distributions, which is out of scope.