### PR TITLE
update __repr__ for BetaNoisePetriNetODESystem

### DIFF
--- a/src/pyciemss/PetriNetODE/base.py
+++ b/src/pyciemss/PetriNetODE/base.py
@@ -389,9 +389,9 @@ class BetaNoisePetriNetODESystem(MiraPetriNetODESystem):
         self.register_buffer("pseudocount", torch.as_tensor(pseudocount))
 
     def __repr__(self):
-        par_string = ",\n".join([f"({get_name(p)}={p.value})" for p in self.G.parameters.values()])
-        count_string = f"pseudocount={self.pseudocount}"
-        return f"{self.__class__.__name__}({par_string},\n{count_string})"
+        par_string = ",\n\t".join([f"{get_name(p)} = {p.value}" for p in self.G.parameters.values()])
+        count_string = f"pseudocount = {self.pseudocount}"
+        return f"{self.__class__.__name__}(\n\t{par_string},\n\t{count_string}\n)"
 
     @pyro.nn.pyro_method
     def observation_model(self, solution: Solution, var_name: str) -> None:


### PR DESCRIPTION
This tiny PR adds newlines to make the printed representation of BetaNoisePetriNetODESystem more readable

*Before*
```python
BetaNoisePetriNetODESystem((a_beta=Uniform(low: 0.8999999761581421, high: 1.100000023841858)), (a_gamma=Uniform(low: 0.8999999761581421, high: 1.100000023841858)), pseudocount=1)
```

*After*
```python
BetaNoisePetriNetODESystem(
	a_beta = Uniform(low: 0.8999999761581421, high: 1.100000023841858),
	a_gamma = Uniform(low: 0.8999999761581421, high: 1.100000023841858),
	pseudocount = 1
)
```