### PR TITLE
Check observations against support

### DIFF
--- a/src/pyciemss/PetriNetODE/interfaces.py
+++ b/src/pyciemss/PetriNetODE/interfaces.py
@@ -86,7 +86,7 @@ def calibrate_petri(petri: PetriNetODESystem,
         for v in obs.observation.values():
             s += v
             assert 0 <= v <= petri.total_population
-        assert 0 <= s <= petri.total_population
+        assert s <= petri.total_population
 
     new_petri.load_events(observations)
 


### PR DESCRIPTION
This PR adds the following asserion to `calibrate_petri`:

```python
    for obs in observations:
        s = 0.0 
        for v in obs.observation.values():
            s += v
            assert 0 <= v <= petri.total_population
        assert s <= petri.total_population
```

Addresses https://github.com/ciemss/pyciemss/issues/110