### PR TITLE
update assertion in `calibrate_petri`

### DIFF
--- a/src/pyciemss/PetriNetODE/interfaces.py
+++ b/src/pyciemss/PetriNetODE/interfaces.py
@@ -92,7 +92,7 @@ def calibrate_petri(petri: PetriNetODESystem,
         for v in obs.observation.values():
             s += v
             assert 0 <= v <= petri.total_population
-        assert torch.isclose(s, petri.total_population)
+        assert s <= petri.total_population or torch.isclose(s, petri.total_population)
     new_petri.load_events(observations)
 
     guide = autoguide(new_petri)


### PR DESCRIPTION
Currently in `calibrate_petri` , we sum the observed values into a local variable `s` and the `assert s <= petri.total_population`. But this can fail due to floating-point roundoff error. This PR changes the line to 
```python
assert s <= petri.total_population or torch.isclose(s, petri.total_population)
```