### PR TITLE
Fix the MIRA version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     torchdiffeq
     networkx
     pandas
-    mira @ git+https://github.com/indralab/mira.git
+    mira @ git+https://github.com/indralab/mira.git@3a3a931ee52c9e5b976ea849424b1a5c65f4c8d2
     xarray
     netcdf4
     h5netcdf


### PR DESCRIPTION
This PR freezes the version of MIRA to the latest working version. This will ensure that any upstream changes to MIRA don't cause breaking changes to PyCIEMSS.