### PR TITLE
Add json files to package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ packages = find:
 package_dir =
     = src
 
+data_files=[('src', ['src/pyciemss/visuals/*.json'])]
+
 [options.packages.find]
 
 where =


### PR DESCRIPTION
**About**: The package when built did not have the json files in the visuals folder, which was causing an error.
This addition line in the setup.cfg file add those json files to the built package so the error should not occur. 
