### PR TITLE
Allow json files to be included in dist package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ packages = find:
 package_dir =
     = src
 
+data_files=[('src', ['src/pyciemss/visuals/*.json'])]
+
 [options.packages.find]
 
 where =


### PR DESCRIPTION
**About**:  With the new changes the code expects a json file to be located in the src/pysiemss/visual folder. This file is in the repo but when you build the package the json files are not found so you get an error like this:

`FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.10/site-packages/pyciemss/visuals/trajectories.vg.json'
`
With the new line in the setup.cfg file lets those files be included in the build. 