### PR TITLE
Disable Pyro parameter sharing through global store

### DIFF
--- a/src/pyciemss/PetriNetODE/base.py
+++ b/src/pyciemss/PetriNetODE/base.py
@@ -506,7 +506,7 @@ class MiraPetriNetODESystem(PetriNetODESystem):
             param_name = get_name(param_info)
             param_value = param_info.value
             if isinstance(param_value, torch.nn.Parameter):
-                setattr(self, param_name, pyro.nn.PyroParam(param_value))
+                setattr(self, param_name, pyro.nn.PyroParam(param_value, constraint=pyro.distributions.constraints.real))
             elif isinstance(param_value, pyro.distributions.Distribution):
                 setattr(self, param_name, pyro.sample(param_name, param_value))
             elif isinstance(param_value, (int, float, numpy.ndarray, torch.Tensor)):

--- a/src/pyciemss/PetriNetODE/base.py
+++ b/src/pyciemss/PetriNetODE/base.py
@@ -506,7 +506,7 @@ class MiraPetriNetODESystem(PetriNetODESystem):
             param_name = get_name(param_info)
             param_value = param_info.value
             if isinstance(param_value, torch.nn.Parameter):
-                setattr(self, param_name, pyro.param(param_name, param_value))
+                setattr(self, param_name, pyro.nn.PyroParam(param_value))
             elif isinstance(param_value, pyro.distributions.Distribution):
                 setattr(self, param_name, pyro.sample(param_name, param_value))
             elif isinstance(param_value, (int, float, numpy.ndarray, torch.Tensor)):

--- a/src/pyciemss/PetriNetODE/base.py
+++ b/src/pyciemss/PetriNetODE/base.py
@@ -34,6 +34,8 @@ from pyciemss.interfaces import DynamicalSystem
 from pyciemss.PetriNetODE.events import (Event, StaticEvent, StartEvent, ObservationEvent,
                                          LoggingEvent, StaticParameterInterventionEvent)
 
+pyro.settings.set(module_local_params=True)
+
 Time = Union[float, torch.tensor]
 State = tuple[torch.tensor]
 StateDeriv = tuple[torch.tensor]

--- a/src/pyciemss/interfaces.py
+++ b/src/pyciemss/interfaces.py
@@ -3,6 +3,9 @@ import pyro
 from typing import TypeVar, Optional
 import functools
 
+# Prevent global parameter store state collison across PyroModules
+pyro.settings.set(module_local_params=True)
+
 # Declare types
 # Note: this doesn't really do anything. More of a placeholder for how derived classes should be declared.
 Data = TypeVar("Data")


### PR DESCRIPTION
This PR sets a configuration option in Pyro to a recommended default value that prevents parameters with the same names from being synchronized across otherwise unconnected `pyro.nn.PyroModule`s.