### PR TITLE
Provide an optional list of parameters to be calibrated deterministically

### DIFF
--- a/src/pyciemss/PetriNetODE/interfaces.py
+++ b/src/pyciemss/PetriNetODE/interfaces.py
@@ -165,7 +165,7 @@ def load_and_calibrate_and_sample_petri_model(
     lr: float = 0.03,
     verbose: bool = False,
     num_particles: int = 1,
-    deterministically_inferred_parameters: Iterable[str] = [],
+    deterministic_learnable_parameters: Iterable[str] = [],
     method="dopri5",
     compile_rate_law_p: bool = True,
     time_unit: Optional[str] = None,
@@ -251,8 +251,8 @@ def load_and_calibrate_and_sample_petri_model(
 
     def autoguide(model):
         guide = AutoGuideList(model)
-        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministically_inferred_parameters)))
-        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministically_inferred_parameters)))
+        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministic_learnable_parameters)))
+        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministic_learnable_parameters)))
         return guide
 
     inferred_parameters = calibrate(
@@ -453,7 +453,7 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
     num_iterations: int = 1000,
     lr: float = 0.03,
     num_particles: int = 1,
-    deterministically_inferred_parameters: Iterable[str] = [],
+    deterministic_learnable_parameters: Iterable[str] = [],
     method="dopri5",
     verbose: bool = False,
     n_samples_ouu: int = int(1e2),
@@ -553,8 +553,8 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
 
     def autoguide(model):
         guide = AutoGuideList(model)
-        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministically_inferred_parameters)))
-        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministically_inferred_parameters)))
+        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministic_learnable_parameters)))
+        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministic_learnable_parameters)))
         return guide
 
     inferred_parameters = calibrate(

--- a/src/pyciemss/PetriNetODE/interfaces.py
+++ b/src/pyciemss/PetriNetODE/interfaces.py
@@ -165,7 +165,7 @@ def load_and_calibrate_and_sample_petri_model(
     lr: float = 0.03,
     verbose: bool = False,
     num_particles: int = 1,
-    deterministicly_inferred_parameters: Iterable[str] = [],
+    deterministically_inferred_parameters: Iterable[str] = [],
     method="dopri5",
     compile_rate_law_p: bool = True,
     time_unit: Optional[str] = None,
@@ -251,8 +251,8 @@ def load_and_calibrate_and_sample_petri_model(
 
     def autoguide(model):
         guide = AutoGuideList(model)
-        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministicly_inferred_parameters)))
-        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministicly_inferred_parameters)))
+        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministically_inferred_parameters)))
+        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministically_inferred_parameters)))
         return guide
 
     inferred_parameters = calibrate(
@@ -453,7 +453,7 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
     num_iterations: int = 1000,
     lr: float = 0.03,
     num_particles: int = 1,
-    deterministicly_inferred_parameters: Iterable[str] = [],
+    deterministically_inferred_parameters: Iterable[str] = [],
     method="dopri5",
     verbose: bool = False,
     n_samples_ouu: int = int(1e2),
@@ -553,8 +553,8 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
 
     def autoguide(model):
         guide = AutoGuideList(model)
-        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministicly_inferred_parameters)))
-        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministicly_inferred_parameters)))
+        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministically_inferred_parameters)))
+        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministically_inferred_parameters)))
         return guide
 
     inferred_parameters = calibrate(

--- a/src/pyciemss/PetriNetODE/interfaces.py
+++ b/src/pyciemss/PetriNetODE/interfaces.py
@@ -165,7 +165,7 @@ def load_and_calibrate_and_sample_petri_model(
     lr: float = 0.03,
     verbose: bool = False,
     num_particles: int = 1,
-    deterministic_parameters: Iterable[str] = [],
+    deterministicly_inferred_parameters: Iterable[str] = [],
     method="dopri5",
     compile_rate_law_p: bool = True,
     time_unit: Optional[str] = None,
@@ -251,8 +251,8 @@ def load_and_calibrate_and_sample_petri_model(
 
     def autoguide(model):
         guide = AutoGuideList(model)
-        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministic_parameters)))
-        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministic_parameters)))
+        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministicly_inferred_parameters)))
+        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministicly_inferred_parameters)))
         return guide
 
     inferred_parameters = calibrate(
@@ -453,7 +453,7 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
     num_iterations: int = 1000,
     lr: float = 0.03,
     num_particles: int = 1,
-    deterministic_parameters: Iterable[str] = [],
+    deterministicly_inferred_parameters: Iterable[str] = [],
     method="dopri5",
     verbose: bool = False,
     n_samples_ouu: int = int(1e2),
@@ -553,8 +553,8 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
 
     def autoguide(model):
         guide = AutoGuideList(model)
-        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministic_parameters)))
-        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministic_parameters)))
+        guide.append(AutoDelta(pyro.poutine.block(model, expose=deterministicly_inferred_parameters)))
+        guide.append(AutoLowRankMultivariateNormal(pyro.poutine.block(model, hide=deterministicly_inferred_parameters)))
         return guide
 
     inferred_parameters = calibrate(

--- a/src/pyciemss/PetriNetODE/interfaces.py
+++ b/src/pyciemss/PetriNetODE/interfaces.py
@@ -164,7 +164,7 @@ def load_and_calibrate_and_sample_petri_model(
     lr: float = 0.03,
     verbose: bool = False,
     num_particles: int = 1,
-    autoguide=pyro.infer.autoguide.AutoLowRankMultivariateNormal,
+    inference_type: str = "probabilistic",
     method="dopri5",
     compile_rate_law_p: bool = True,
     time_unit: Optional[str] = None,
@@ -227,6 +227,15 @@ def load_and_calibrate_and_sample_petri_model(
                 * data: PetriSolution: The samples from the calibrated model as a pandas DataFrame. (If visual_options is falsy)
                 * visual: Visualization. (If visual_options is truthy)
     """
+    if inference_type == "probabilistic":
+        autoguide = pyro.infer.autoguide.AutoLowRankMultivariateNormal
+    elif inference_type == "deterministic":
+        autoguide = pyro.infer.autoguide.AutoDelta
+    else:
+        raise ValueError(
+            f"Invalid inference_type {inference_type}. Must be one of 'probabilistic' or 'deterministic'."
+        )
+
     data = csv_to_list(data_path)
 
     model = load_petri_model(
@@ -446,7 +455,7 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
     num_iterations: int = 1000,
     lr: float = 0.03,
     num_particles: int = 1,
-    autoguide=pyro.infer.autoguide.AutoLowRankMultivariateNormal,
+    inference_type: str = "probabilistic",
     method="dopri5",
     verbose: bool = False,
     n_samples_ouu: int = int(1e2),
@@ -526,6 +535,15 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
                         * samples: Samples from the model at the optimal intervention
                         * qoi: Samples of quantity of interest
     """
+    if inference_type == "probabilistic":
+        autoguide = pyro.infer.autoguide.AutoLowRankMultivariateNormal
+    elif inference_type == "deterministic":
+        autoguide = pyro.infer.autoguide.AutoDelta
+    else:
+        raise ValueError(
+            f"Invalid inference_type {inference_type}. Must be one of 'probabilistic' or 'deterministic'."
+        )
+
     data = csv_to_list(data_path)
 
     model = load_petri_model(

--- a/test/test_petrinet_ode/test_ode_interfaces.py
+++ b/test/test_petrinet_ode/test_ode_interfaces.py
@@ -65,7 +65,7 @@ class TestSamplesFormat(unittest.TestCase):
             cls.num_samples,
             timepoints=timepoints,
             num_iterations=2,
-            deterministically_inferred_parameters=["beta"],
+            deterministic_learnable_parameters=["beta"],
         )["data"]
 
         cls.interventions = [(1., "beta", 1.0), (2.1, "gamma", 0.1)]

--- a/test/test_petrinet_ode/test_ode_interfaces.py
+++ b/test/test_petrinet_ode/test_ode_interfaces.py
@@ -66,9 +66,8 @@ class TestSamplesFormat(unittest.TestCase):
             cls.num_samples,
             timepoints=timepoints,
             num_iterations=2,
-            inference_type="deterministic",
+            deterministic_parameters=["beta"],
         )["data"]
-
 
         cls.interventions = [(1., "beta", 1.0), (2.1, "gamma", 0.1)]
         cls.intervened_samples = load_and_sample_petri_model(

--- a/test/test_petrinet_ode/test_ode_interfaces.py
+++ b/test/test_petrinet_ode/test_ode_interfaces.py
@@ -41,6 +41,7 @@ class TestSamplesFormat(unittest.TestCase):
         cls.num_samples = 2
         timepoints = [0.0, 1.0, 2.0, 3.0, 4.0]
         cls.num_timepoints = len(timepoints)
+        data_path = os.path.join(DEMO_PATH, "data.csv")
 
         cls.samples = load_and_sample_petri_model(
             ASKENET_PATH,
@@ -48,8 +49,6 @@ class TestSamplesFormat(unittest.TestCase):
             timepoints=timepoints,
             method="euler",
         )["data"]
-
-        data_path = os.path.join(DEMO_PATH, "data.csv")
 
         cls.calibrated_samples = load_and_calibrate_and_sample_petri_model(
             ASKENET_PATH,
@@ -117,6 +116,13 @@ class TestSamplesFormat(unittest.TestCase):
 
         cls.all_samples = [cls.samples, cls.calibrated_samples, cls.calibrated_samples_deterministic, cls.intervened_samples, cls.ouu_samples, cls.ouu_cal_samples]
 
+    def test_deterministic_calibrated_samples(self):
+        # Add additional test that checks that the deterministic parameters are actually deterministic
+        beta = self.calibrated_samples_deterministic["beta_param"].values
+        gamma = self.calibrated_samples_deterministic["gamma_param"].values
+        self.assertEqual(beta[:self.num_timepoints].tolist(), beta[self.num_timepoints:].tolist(), "beta is deterministic during calibration")
+        self.assertNotEqual(gamma[:self.num_timepoints].tolist(), gamma[self.num_timepoints:].tolist(), "gamma is not deterministic during calibration")
+
     def test_samples_type(self):
         """Test that `samples` is a Pandas DataFrame"""
         for s in self.all_samples:
@@ -145,6 +151,7 @@ class TestSamplesFormat(unittest.TestCase):
 
 class TestAMRDistribution(unittest.TestCase):
     """Tests for the distribution of the AMR model."""
+    
     def test_distribution(self):
         filepath = "test/models/AMR_examples/scenario1_c_with_distributions.json"
         samples = load_and_sample_petri_model(

--- a/test/test_petrinet_ode/test_ode_interfaces.py
+++ b/test/test_petrinet_ode/test_ode_interfaces.py
@@ -65,7 +65,7 @@ class TestSamplesFormat(unittest.TestCase):
             cls.num_samples,
             timepoints=timepoints,
             num_iterations=2,
-            deterministicly_inferred_parameters=["beta"],
+            deterministically_inferred_parameters=["beta"],
         )["data"]
 
         cls.interventions = [(1., "beta", 1.0), (2.1, "gamma", 0.1)]

--- a/test/test_petrinet_ode/test_ode_interfaces.py
+++ b/test/test_petrinet_ode/test_ode_interfaces.py
@@ -65,7 +65,7 @@ class TestSamplesFormat(unittest.TestCase):
             cls.num_samples,
             timepoints=timepoints,
             num_iterations=2,
-            deterministic_parameters=["beta"],
+            deterministicly_inferred_parameters=["beta"],
         )["data"]
 
         cls.interventions = [(1., "beta", 1.0), (2.1, "gamma", 0.1)]


### PR DESCRIPTION
This small PR adds a flag to our interface methods that triggers whether to run SVI with some subset of the parameters being calibrated deterministically.

Note: This implementation is made easy by the fact that variational inference with dirac-Delta distribution is exactly equivalent to MAP inference. We concatenate a autoguide using Pyro's `AutoGuideList` constructor.