### PR TITLE
Add deterministic_learnable_parameters to docstring

### DIFF
--- a/src/pyciemss/PetriNetODE/interfaces.py
+++ b/src/pyciemss/PetriNetODE/interfaces.py
@@ -238,8 +238,8 @@ def load_and_calibrate_and_sample_petri_model(
             - Whether to print out the calibration progress. This will include summaries of the evidence lower bound (ELBO) and the parameters.
         num_particles: int > 0
             - The number of particles to use for the calibration. Increasing this value will result in lower variance gradient estimates, but will also increase the computational cost per gradient step.
-        autoguide: pyro.infer.autoguide.AutoGuide
-            - The guide to use for the calibration. By default we use the AutoLowRankMultivariateNormal guide. This is an advanced option. Please see the Pyro documentation for more details.
+        deterministic_learnable_parameters: Iterable[str]
+            - The set of parameters whose calibration output will be point estimates that were learned from data. 
         method: str
             - The method to use for the ODE solver. See `torchdiffeq.odeint` for more details.
             - If performance is incredibly slow, we suggest using `euler` to debug. If using `euler` results in faster simulation, the issue is likely that the model is stiff.
@@ -609,8 +609,8 @@ def load_and_calibrate_and_optimize_and_sample_petri_model(
             - Whether to print out the calibration progress and the optimization under uncertainty progress. This will include summaries of the evidence lower bound (ELBO) and the parameters.
         num_particles: int > 0
             - The number of particles to use for the calibration. Increasing this value will result in lower variance gradient estimates, but will also increase the computational cost per gradient step.
-        autoguide: pyro.infer.autoguide.AutoGuide
-            - The guide to use for the calibration. By default we use the AutoLowRankMultivariateNormal guide. This is an advanced option. Please see the Pyro documentation for more details.
+        deterministic_learnable_parameters: Iterable[str]
+            - The set of parameters whose calibration output will be point estimates that were learned from data. 
         method: str
             - The method to use for solving the ODE. See torchdiffeq's `odeint` method for more details.
             - If performance is incredibly slow, we suggest using `euler` to debug. If using `euler` results in faster simulation, the issue is likely that the model is stiff.


### PR DESCRIPTION
Replace the deprecated autoguide parameter docstring with this:

```
deterministic_learnable_parameters: Iterable[str]
            - The set of parameters whose calibration output will be point estimates that were learned from data. ```

for both `load_and_calibrate_and_sample` and `load_and_calibrate_and_optimize_and_sample`