### PR TITLE
Fix calibration so that it no longer fails when there no latent variables in the model.

### DIFF
--- a/notebook/visual examples/Graphs.ipynb
+++ b/notebook/visual examples/Graphs.ipynb
@@ -450,7 +450,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/notebook/visual examples/TrajectoryVisualizations.ipynb
+++ b/notebook/visual examples/TrajectoryVisualizations.ipynb
@@ -12789,7 +12789,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ASKEM",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -12803,10 +12803,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
-  },
-  "orig_nbformat": 4
+   "version": "3.8.16"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebook/visual examples/Visual Checks.ipynb
+++ b/notebook/visual examples/Visual Checks.ipynb
@@ -133,7 +133,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/test/test_petrinet_ode/test_learnable_parameters.py
+++ b/test/test_petrinet_ode/test_learnable_parameters.py
@@ -1,0 +1,164 @@
+import unittest
+import os
+
+import sympy
+from mira.metamodel import (
+    Concept,
+    ControlledConversion,
+    Initial,
+    NaturalConversion,
+    Parameter,
+    TemplateModel,
+    Distribution,
+)
+
+import os
+from pyciemss.PetriNetODE.interfaces import (
+    load_and_calibrate_and_sample_petri_model,
+)
+
+class TestLearnableParameters(unittest.TestCase):
+    """Test that learnable parameters can be calibrated."""
+    def setUp(self):
+        """Load the model with only learnable parameters."""
+        DEMO_PATH = "notebook/integration_demo/"
+        self.data_path = os.path.join(DEMO_PATH, "data.csv")
+        beta, gamma, S, I, R, total_population = sympy.symbols(
+            "beta, gamma, S, I, R, total_population"
+        )
+
+        susceptible = Concept(
+            name="S", identifiers={"ido": "0000514"}
+        )
+        infected = Concept(
+            name="I", identifiers={"ido": "0000573"}
+        )  # http://purl.obolibrary.org/obo/IDO_0000573
+        recovered = Concept(name="R", identifiers={"ido": "0000592"})
+        total_pop = 1.0
+
+        S_to_I = ControlledConversion(
+            controller=infected,
+            subject=susceptible,
+            outcome=infected,
+            rate_law=beta * S * I / (S + I + R),
+        )
+        I_to_R = NaturalConversion(
+            subject=infected, outcome=recovered, rate_law=gamma * I
+        )
+        self.all_learnable_parameters = TemplateModel(
+            templates=[S_to_I, I_to_R],
+            parameters={
+                "beta": Parameter(name="beta", value=0.55),  # transmission rate
+                "gamma": Parameter(name="gamma", value=0.2),  # recovery rate
+            },
+            initials={
+                "S": (
+                    Initial(concept=susceptible, value=(total_pop - 0.01))
+                ),
+                "I": (Initial(concept=infected, value=0.01)),
+                "R": (Initial(concept=recovered, value=0)),
+            },
+        )
+        self.gamma_learnable_parameters = TemplateModel(
+            templates=[S_to_I, I_to_R],
+            parameters={
+                "beta": Parameter(name="beta", value=0.55,
+                                  distribution=Distribution(type='Uniform1',
+                                                            parameters={'minimum': 0.5, 'maximum': 0.6})),
+                # transmission rate
+                "gamma": Parameter(name="gamma", value=0.2),  # recovery rate
+            },
+            initials={
+                "S": (
+                    Initial(concept=susceptible, value=(total_pop - 1))
+                ),
+                "I": (Initial(concept=infected, value=1)),
+                "R": (Initial(concept=recovered, value=0)),
+            },
+        )
+        self.beta_learnable_parameters = TemplateModel(
+            templates=[S_to_I, I_to_R],
+            parameters={
+                "beta": Parameter(name="beta", value=0.55),  # transmission rate
+                "gamma": Parameter(name="gamma", value=0.2,
+                                   distribution=Distribution(type='Uniform1',
+                                                             parameters={'minimum': 0.1, 'maximum': 0.3}
+                                                             )
+                                   ),
+            },
+            initials={
+                "S": (
+                    Initial(concept=susceptible, value=(total_pop - 1))
+                ),
+                "I": (Initial(concept=infected, value=1)),
+                "R": (Initial(concept=recovered, value=0)),
+            },
+        )
+        
+        self.no_learnable_parameters = TemplateModel(
+            templates=[S_to_I, I_to_R],
+            parameters={
+                "beta": Parameter(name="beta", value=0.55,
+                                  distribution=Distribution(type='Uniform1',
+                                                            parameters={'minimum': 0.5, 'maximum': 0.6})),
+                                  # transmission rate
+                "gamma": Parameter(name="gamma", value=0.2,
+                                   distribution=Distribution(type='Uniform1',
+                                                             parameters={'minimum': 0.1, 'maximum': 0.3})),
+                # recovery rate
+            },
+            initials={
+                "S": (
+                    Initial(concept=susceptible, value=(total_pop - 1))
+                ),
+                "I": (Initial(concept=infected, value=1)),
+                "R": (Initial(concept=recovered, value=0)),
+            },
+        )
+            
+    
+    def test_calibrate_fails_on_learned_parameters(self):
+        """Test that calibrate does not fail when the model has only learned parameters."""
+        num_samples = 2
+        timepoints = [0.0, 1.0, 2.0, 3.0, 4.0]
+        num_timepoints = len(timepoints)
+
+
+        self.assertTrue(
+            type(
+                load_and_calibrate_and_sample_petri_model(
+                    self.gamma_learnable_parameters,
+                    self.data_path,
+                    num_samples,
+                    timepoints=timepoints,
+                    method='euler',
+                ) is dict))
+        
+        self.assertTrue(
+            type(
+                load_and_calibrate_and_sample_petri_model(
+                    self.beta_learnable_parameters,
+                    self.data_path,
+                    num_samples,
+                    timepoints=timepoints,
+                    method='euler',
+                ) is dict))
+        self.assertTrue(
+            type(
+                load_and_calibrate_and_sample_petri_model(
+                    self.no_learnable_parameters,
+                    self.data_path,
+                    num_samples,
+                    timepoints=timepoints,
+                    method='euler',
+                ) is dict))
+        self.assertTrue(
+            type(load_and_calibrate_and_sample_petri_model(
+                self.all_learnable_parameters,
+                self.data_path,
+                num_samples,
+                timepoints=timepoints,
+                method='euler',
+            ) is dict))
+        
+                 

--- a/test/test_petrinet_ode/test_learnable_parameters.py
+++ b/test/test_petrinet_ode/test_learnable_parameters.py
@@ -45,7 +45,7 @@ class TestLearnableParameters(unittest.TestCase):
         I_to_R = NaturalConversion(
             subject=infected, outcome=recovered, rate_law=gamma * I
         )
-        self.all_learnable_parameters = TemplateModel(
+        self.no_distribution_parameters = TemplateModel(
             templates=[S_to_I, I_to_R],
             parameters={
                 "beta": Parameter(name="beta", value=0.55),  # transmission rate
@@ -59,7 +59,7 @@ class TestLearnableParameters(unittest.TestCase):
                 "R": (Initial(concept=recovered, value=0)),
             },
         )
-        self.gamma_learnable_parameters = TemplateModel(
+        self.beta_only_distribution = TemplateModel(
             templates=[S_to_I, I_to_R],
             parameters={
                 "beta": Parameter(name="beta", value=0.55,
@@ -76,7 +76,7 @@ class TestLearnableParameters(unittest.TestCase):
                 "R": (Initial(concept=recovered, value=0)),
             },
         )
-        self.beta_learnable_parameters = TemplateModel(
+        self.gamma_only_distribution = TemplateModel(
             templates=[S_to_I, I_to_R],
             parameters={
                 "beta": Parameter(name="beta", value=0.55),  # transmission rate
@@ -95,7 +95,7 @@ class TestLearnableParameters(unittest.TestCase):
             },
         )
         
-        self.no_learnable_parameters = TemplateModel(
+        self.all_distribution_parameters = TemplateModel(
             templates=[S_to_I, I_to_R],
             parameters={
                 "beta": Parameter(name="beta", value=0.55,
@@ -118,7 +118,7 @@ class TestLearnableParameters(unittest.TestCase):
             
     
     def test_calibrate_fails_on_learned_parameters(self):
-        """Test that calibrate does not fail when the model has only learned parameters."""
+        """Test that calibrate fails when the model has only non-distribution parameters."""
         num_samples = 2
         timepoints = [0.0, 1.0, 2.0, 3.0, 4.0]
         num_timepoints = len(timepoints)
@@ -127,7 +127,7 @@ class TestLearnableParameters(unittest.TestCase):
         self.assertTrue(
             type(
                 load_and_calibrate_and_sample_petri_model(
-                    self.gamma_learnable_parameters,
+                    self.beta_only_distribution,
                     self.data_path,
                     num_samples,
                     timepoints=timepoints,
@@ -137,7 +137,7 @@ class TestLearnableParameters(unittest.TestCase):
         self.assertTrue(
             type(
                 load_and_calibrate_and_sample_petri_model(
-                    self.beta_learnable_parameters,
+                    self.gamma_only_distribution,
                     self.data_path,
                     num_samples,
                     timepoints=timepoints,
@@ -146,19 +146,70 @@ class TestLearnableParameters(unittest.TestCase):
         self.assertTrue(
             type(
                 load_and_calibrate_and_sample_petri_model(
-                    self.no_learnable_parameters,
+                    self.all_distribution_parameters,
                     self.data_path,
                     num_samples,
                     timepoints=timepoints,
                     method='euler',
                 ) is dict))
         self.assertTrue(
-            type(load_and_calibrate_and_sample_petri_model(
-                self.all_learnable_parameters,
+            type(
+                load_and_calibrate_and_sample_petri_model(
+                    self.beta_only_distribution,
+                    self.data_path,
+                    num_samples,
+                    timepoints=timepoints,
+                    method='euler',
+                    deterministic_learnable_parameters=['gamma'],
+                ) is dict))
+       
+        with self.assertRaises(RuntimeError):
+            load_and_calibrate_and_sample_petri_model(
+                self.gamma_only_distribution,
                 self.data_path,
                 num_samples,
                 timepoints=timepoints,
                 method='euler',
-            ) is dict))
+                deterministic_learnable_parameters=['beta', 'gamma'],
+            )
+         
+        with self.assertRaises(RuntimeError):
+            load_and_calibrate_and_sample_petri_model(
+                self.gamma_only_distribution,
+                self.data_path,
+                num_samples,
+                timepoints=timepoints,
+                method='euler',
+                deterministic_learnable_parameters=['gamma'],
+            )
+        with self.assertRaises(RuntimeError):
+            load_and_calibrate_and_sample_petri_model(
+                self.all_distribution_parameters,
+                self.data_path,
+                num_samples,
+                timepoints=timepoints,
+                method='euler',
+                deterministic_learnable_parameters=['beta', 'gamma'],
+            )
+        with self.assertRaises(RuntimeError):
+            load_and_calibrate_and_sample_petri_model(
+                self.no_distribution_parameters,
+                self.data_path,
+                num_samples,
+                timepoints=timepoints,
+                method='euler',
+                )
+        with self.assertRaises(RuntimeError):
+            load_and_calibrate_and_sample_petri_model(
+                self.no_distribution_parameters,
+                self.data_path,
+                num_samples,
+                timepoints=timepoints,
+                method='euler',
+                deterministic_learnable_parameters=['beta', 'gamma'],
+                )
+            
+        
+
         
                  

--- a/test/test_petrinet_ode/test_ode_interfaces.py
+++ b/test/test_petrinet_ode/test_ode_interfaces.py
@@ -515,6 +515,7 @@ class TestODEInterfaces(unittest.TestCase):
         # Density should be greater than 0 inside the support.
         self.assertGreater(density[1].item(), 0.)
 
+
     # def test_optimize(self):
     #     '''Test the optimize function.'''
     #     model = load_petri_model(self.filename)

--- a/test/test_petrinet_ode/test_ode_interfaces.py
+++ b/test/test_petrinet_ode/test_ode_interfaces.py
@@ -516,6 +516,8 @@ class TestODEInterfaces(unittest.TestCase):
         self.assertGreater(density[1].item(), 0.)
 
 
+
+
     # def test_optimize(self):
     #     '''Test the optimize function.'''
     #     model = load_petri_model(self.filename)


### PR DESCRIPTION


```python
$ pytest test/test_petrinet_ode/test_learnable_parameters.py
============================================================================================= test session starts ==============================================================================================
platform darwin -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss
plugins: anyio-3.7.0
collected 1 item                                                                                                                                                                                               

test/test_petrinet_ode/test_learnable_parameters.py F                                                                                                                                                    [100%]

=================================================================================================== FAILURES ===================================================================================================
______________________________________________________________________ TestLearnableParameters.test_calibrate_fails_on_learned_parameters ______________________________________________________________________

self = <pyro.poutine.trace_messenger.TraceHandler object at 0x14eef2110>, args = (), kwargs = {'method': 'euler'}, exc_type = <class 'RuntimeError'>
exc_value = RuntimeError('AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead'), traceback = <traceback object at 0x14ee76bc0>
shapes = 'Trace Shapes:\n Param Sites:\nSample Sites:', exc = RuntimeError('AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead\nTrace Shapes:\n Param Sites:\nSample Sites:')

    def __call__(self, *args, **kwargs):
        """
        Runs the stochastic function stored in this poutine,
        with additional side effects.
    
        Resets self.trace to an empty trace,
        installs itself on the global execution stack,
        runs self.fn with the given arguments,
        uninstalls itself from the global execution stack,
        stores the arguments and return value of the function in special sites,
        and returns self.fn's return value
        """
        with self.msngr:
            self.msngr.trace.add_node(
                "_INPUT", name="_INPUT", type="args", args=args, kwargs=kwargs
            )
            try:
>               ret = self.fn(*args, **kwargs)

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py:174: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoGuideList(
  (0): AutoDelta()
  (1): AutoLowRankMultivariateNormal()
), args = (), kwargs = {'method': 'euler'}

    def __call__(self, *args, **kwargs):
        with self._pyro_context:
>           result = super().__call__(*args, **kwargs)

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py:448: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoGuideList(
  (0): AutoDelta()
  (1): AutoLowRankMultivariateNormal()
), input = (), kwargs = {'method': 'euler'}
forward_call = <bound method AutoGuideList.forward of AutoGuideList(
  (0): AutoDelta()
  (1): AutoLowRankMultivariateNormal()
)>

    def _call_impl(self, *input, **kwargs):
        forward_call = (self._slow_forward if torch._C._get_tracing_state() else self.forward)
        # If we don't have any hooks, we want to skip the rest of the logic in
        # this function, and just call forward.
        if not (self._backward_hooks or self._forward_hooks or self._forward_pre_hooks or _global_backward_hooks
                or _global_forward_hooks or _global_forward_pre_hooks):
>           return forward_call(*input, **kwargs)

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py:1194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoGuideList(
  (0): AutoDelta()
  (1): AutoLowRankMultivariateNormal()
), args = (), kwargs = {'method': 'euler'}, result = {}, part = AutoLowRankMultivariateNormal()

    def forward(self, *args, **kwargs):
        """
        A composite guide with the same ``*args, **kwargs`` as the base ``model``.
    
        .. note:: This method is used internally by :class:`~torch.nn.Module`.
            Users should instead use :meth:`~torch.nn.Module.__call__`.
    
        :return: A dict mapping sample site name to sampled value.
        :rtype: dict
        """
        # if we've never run the model before, do so now so we can inspect the model structure
        if self.prototype_trace is None:
            self._setup_prototype(*args, **kwargs)
    
        # create all plates
        self._create_plates(*args, **kwargs)
    
        # run slave guides
        result = {}
        for part in self:
>           result.update(part(*args, **kwargs))

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:249: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoLowRankMultivariateNormal(), args = (), kwargs = {'method': 'euler'}

    def __call__(self, *args, **kwargs):
        with self._pyro_context:
>           result = super().__call__(*args, **kwargs)

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py:448: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoLowRankMultivariateNormal(), input = (), kwargs = {'method': 'euler'}, forward_call = <bound method AutoContinuous.forward of AutoLowRankMultivariateNormal()>

    def _call_impl(self, *input, **kwargs):
        forward_call = (self._slow_forward if torch._C._get_tracing_state() else self.forward)
        # If we don't have any hooks, we want to skip the rest of the logic in
        # this function, and just call forward.
        if not (self._backward_hooks or self._forward_hooks or self._forward_pre_hooks or _global_backward_hooks
                or _global_forward_hooks or _global_forward_pre_hooks):
>           return forward_call(*input, **kwargs)

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py:1194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoLowRankMultivariateNormal(), args = (), kwargs = {'method': 'euler'}

    def forward(self, *args, **kwargs):
        """
        An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
    
        .. note:: This method is used internally by :class:`~torch.nn.Module`.
            Users should instead use :meth:`~torch.nn.Module.__call__`.
    
        :return: A dict mapping sample site name to sampled value.
        :rtype: dict
        """
        # if we've never run the model before, do so now so we can inspect the model structure
        if self.prototype_trace is None:
>           self._setup_prototype(*args, **kwargs)

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:759: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoLowRankMultivariateNormal(), args = (), kwargs = {'method': 'euler'}

    def _setup_prototype(self, *args, **kwargs):
>       super()._setup_prototype(*args, **kwargs)

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:999: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoLowRankMultivariateNormal(), args = (), kwargs = {'method': 'euler'}

    def _setup_prototype(self, *args, **kwargs):
        super()._setup_prototype(*args, **kwargs)
        self._unconstrained_shapes = {}
        self._cond_indep_stacks = {}
        for name, site in self.prototype_trace.iter_stochastic_nodes():
            # Collect the shapes of unconstrained values.
            # These may differ from the shapes of constrained values.
            with helpful_support_errors(site):
                self._unconstrained_shapes[name] = (
                    biject_to(site["fn"].support).inv(site["value"]).shape
                )
    
            # Collect independence contexts.
            self._cond_indep_stacks[name] = site["cond_indep_stack"]
    
        self.latent_dim = sum(
            _product(shape) for shape in self._unconstrained_shapes.values()
        )
        if self.latent_dim == 0:
>           raise RuntimeError(
                "{} found no latent variables; Use an empty guide instead".format(
                    type(self).__name__
                )
            )
E           RuntimeError: AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:654: RuntimeError

The above exception was the direct cause of the following exception:

self = <test_learnable_parameters.TestLearnableParameters testMethod=test_calibrate_fails_on_learned_parameters>

    def test_calibrate_fails_on_learned_parameters(self):
        """Test that calibrate does not fail when the model has only learned parameters."""
        num_samples = 2
        timepoints = [0.0, 1.0, 2.0, 3.0, 4.0]
        num_timepoints = len(timepoints)
    
    
        self.assertTrue(
            type(
                load_and_calibrate_and_sample_petri_model(
                    self.gamma_learnable_parameters,
                    self.data_path,
                    num_samples,
                    timepoints=timepoints,
                    method='euler',
                ) is dict))
    
        self.assertTrue(
            type(
                load_and_calibrate_and_sample_petri_model(
                    self.beta_learnable_parameters,
                    self.data_path,
                    num_samples,
                    timepoints=timepoints,
                    method='euler',
                ) is dict))
        self.assertTrue(
            type(
                load_and_calibrate_and_sample_petri_model(
                    self.no_learnable_parameters,
                    self.data_path,
                    num_samples,
                    timepoints=timepoints,
                    method='euler',
                ) is dict))
        self.assertTrue(
>           type(load_and_calibrate_and_sample_petri_model(
                self.all_learnable_parameters,
                self.data_path,
                num_samples,
                timepoints=timepoints,
                method='euler',
            ) is dict))

test/test_petrinet_ode/test_learnable_parameters.py:156: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/pyciemss/custom_decorators.py:30: in wrapped
    raise e
src/pyciemss/custom_decorators.py:9: in wrapped
    result = function(*args, **kwargs)
src/pyciemss/PetriNetODE/interfaces.py:305: in load_and_calibrate_and_sample_petri_model
    inferred_parameters = calibrate(
/Users/zuck016/.pyenv/versions/3.10.9/lib/python3.10/functools.py:889: in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
src/pyciemss/custom_decorators.py:30: in wrapped
    raise e
src/pyciemss/custom_decorators.py:9: in wrapped
    result = function(*args, **kwargs)
src/pyciemss/PetriNetODE/interfaces.py:887: in calibrate_petri
    loss = svi.step(method=method)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/svi.py:145: in step
    loss = self.loss_and_grads(self.model, self.guide, *args, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/trace_elbo.py:140: in loss_and_grads
    for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/elbo.py:236: in _get_traces
    yield self._get_trace(model, guide, args, kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/trace_elbo.py:57: in _get_trace
    model_trace, guide_trace = get_importance_trace(
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/enum.py:60: in get_importance_trace
    guide_trace = poutine.trace(guide, graph_type=graph_type).get_trace(
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py:198: in get_trace
    self(*args, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py:180: in __call__
    raise exc from e
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py:174: in __call__
    ret = self.fn(*args, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py:448: in __call__
    result = super().__call__(*args, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py:1194: in _call_impl
    return forward_call(*input, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:249: in forward
    result.update(part(*args, **kwargs))
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py:448: in __call__
    result = super().__call__(*args, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py:1194: in _call_impl
    return forward_call(*input, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:759: in forward
    self._setup_prototype(*args, **kwargs)
/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:999: in _setup_prototype
    super()._setup_prototype(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = AutoLowRankMultivariateNormal(), args = (), kwargs = {'method': 'euler'}

    def _setup_prototype(self, *args, **kwargs):
        super()._setup_prototype(*args, **kwargs)
        self._unconstrained_shapes = {}
        self._cond_indep_stacks = {}
        for name, site in self.prototype_trace.iter_stochastic_nodes():
            # Collect the shapes of unconstrained values.
            # These may differ from the shapes of constrained values.
            with helpful_support_errors(site):
                self._unconstrained_shapes[name] = (
                    biject_to(site["fn"].support).inv(site["value"]).shape
                )
    
            # Collect independence contexts.
            self._cond_indep_stacks[name] = site["cond_indep_stack"]
    
        self.latent_dim = sum(
            _product(shape) for shape in self._unconstrained_shapes.values()
        )
        if self.latent_dim == 0:
>           raise RuntimeError(
                "{} found no latent variables; Use an empty guide instead".format(
                    type(self).__name__
                )
            )
E           RuntimeError: AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead
E           Trace Shapes:
E            Param Sites:
E           Sample Sites:

/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py:654: RuntimeError
---------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------
ERROR    root:custom_decorators.py:29 
                ###############################

                There was an exception in pyciemss
                
                Error occured in function: calibrate_petri

                Function docs : 
    Use variational inference with a mean-field variational family to infer the parameters of the model.
    

                ################################
            
Traceback (most recent call last):
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 174, in __call__
    ret = self.fn(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 249, in forward
    result.update(part(*args, **kwargs))
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 759, in forward
    self._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 999, in _setup_prototype
    super()._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 654, in _setup_prototype
    raise RuntimeError(
RuntimeError: AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss/src/pyciemss/custom_decorators.py", line 9, in wrapped
    result = function(*args, **kwargs)
  File "/Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss/src/pyciemss/PetriNetODE/interfaces.py", line 887, in calibrate_petri
    loss = svi.step(method=method)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/svi.py", line 145, in step
    loss = self.loss_and_grads(self.model, self.guide, *args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/trace_elbo.py", line 140, in loss_and_grads
    for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/elbo.py", line 236, in _get_traces
    yield self._get_trace(model, guide, args, kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/trace_elbo.py", line 57, in _get_trace
    model_trace, guide_trace = get_importance_trace(
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/enum.py", line 60, in get_importance_trace
    guide_trace = poutine.trace(guide, graph_type=graph_type).get_trace(
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 198, in get_trace
    self(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 180, in __call__
    raise exc from e
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 174, in __call__
    ret = self.fn(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 249, in forward
    result.update(part(*args, **kwargs))
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 759, in forward
    self._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 999, in _setup_prototype
    super()._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 654, in _setup_prototype
    raise RuntimeError(
RuntimeError: AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead
Trace Shapes:
 Param Sites:
Sample Sites:
ERROR    root:custom_decorators.py:29 
                ###############################

                There was an exception in pyciemss
                
                Error occured in function: load_and_calibrate_and_sample_petri_model

                Function docs : 
    Load a petri net from a file, compile it into a probabilistic program, calibrate it on data,
    and sample from the calibrated model.

    Args:
        petri_model_or_path: Union[str, mira.metamodel.TemplateModel, mira.modeling.Model]
            - A path to a petri net file, or a petri net object.
            - This path can be a URL or a local path to a mira model or AMR model.
            - Alternatively, this can be a mira template model directly.
        data_path: str
            - The path to the data to calibrate the model to. See notebook/integration_demo/data.csv for an example of the format.
        num_samples: int
            - The number of samples to draw from the model.
        timepoints: [Iterable[float]]
            - The timepoints to simulate the model from. Backcasting and/or forecasting is reflected in the choice of timepoints.
        noise_model: str
            - The noise model to use for the model.
            - Options are "scaled_beta" and "scaled_normal".
        noise_scale: float > 0.0
            - A scaling parameter for the noise model.
            - Larger values of noise_scale correspond to more certainty about the model parameters.
        interventions: Optional[Iterable[Tuple[float, str, float]]]
            - A list of interventions to apply to the model. Each intervention is a tuple of the form (time, parameter_name, value).
        start_state: Optional[dict[str, float]]
            - The initial state of the model. If None, the initial state is taken from the mira model.
        start_time: float
            - The start time of the model. This is used to align the `start_state` with the `timepoints`.
            - By default we set the `start_time` to be a small negative number to avoid numerical issues w/ collision with the `timepoints` which typically start at 0.
        num_iterations: int > 0
            - The number of iterations to run the calibration for.
        lr: float > 0.0
            - The learning rate to use for the calibration.
        verbose: bool
            - Whether to print out the calibration progress. This will include summaries of the evidence lower bound (ELBO) and the parameters.
        num_particles: int > 0
            - The number of particles to use for the calibration. Increasing this value will result in lower variance gradient estimates, but will also increase the computational cost per gradient step.
        deterministic_learnable_parameters: Iterable[str]
            - The set of parameters whose calibration output will be point estimates that were learned from data. 
        method: str
            - The method to use for the ODE solver. See `torchdiffeq.odeint` for more details.
            - If performance is incredibly slow, we suggest using `euler` to debug. If using `euler` results in faster simulation, the issue is likely that the model is stiff.
        compile_rate_law_p: bool
            - Whether or not to compile the rate law from the AMR rate expression. default True.  False is useful for debugging.
        compile_observables_p: bool
            - Whether or not to compile the observables from the AMR observable expression. default True.  False is useful for debugging.
        time_unit: str
            - Time unit (used for labeling outputs)
        visual_options: None, bool, dict[str, any]
            - True output a visual
            - False do not output a visual
            - dict output a visual with the dictionary passed to the visualization as kwargs
        progress_hook: Callable
            - The hook transmitting the current progress of the calibration.
        alpha_qs: Optional[Iterable[float]]
            - The quantiles required for estimating weighted interval score to test ensemble forecasting accuracy.
        stacking_order: Optional[str]
            - The stacking order requested for the ensemble quantiles to keep the selected quantity together for each state.
            - Options: "timepoints" or "quantiles"

    Returns:
        result: dict
            - Dictionary of outputs with following attribute:
                * data: The samples from the calibrated model as a pandas DataFrame.
                * quantiles: The quantiles for ensemble score calculation after calibration as a pandas DataFrames.
                * risk: Risk estimates for each state as 2-day average at the final timepoint
                    * risk: Estimated alpha-superquantile risk with alpha=0.95
                    * qoi: Samples of quantity of interest (in this case, 2-day average of the state at the final timepoint)
                * inferred_parameters: The inferred parameters from the calibration as PetriInferredParameters.
                * visual: Visualization. (If visual_options is truthy)
    

                ################################
            
Traceback (most recent call last):
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 174, in __call__
    ret = self.fn(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 249, in forward
    result.update(part(*args, **kwargs))
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 759, in forward
    self._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 999, in _setup_prototype
    super()._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 654, in _setup_prototype
    raise RuntimeError(
RuntimeError: AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss/src/pyciemss/custom_decorators.py", line 9, in wrapped
    result = function(*args, **kwargs)
  File "/Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss/src/pyciemss/PetriNetODE/interfaces.py", line 305, in load_and_calibrate_and_sample_petri_model
    inferred_parameters = calibrate(
  File "/Users/zuck016/.pyenv/versions/3.10.9/lib/python3.10/functools.py", line 889, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss/src/pyciemss/custom_decorators.py", line 30, in wrapped
    raise e
  File "/Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss/src/pyciemss/custom_decorators.py", line 9, in wrapped
    result = function(*args, **kwargs)
  File "/Users/zuck016/Projects/Proposals/ASKEM/build/pyciemss/src/pyciemss/PetriNetODE/interfaces.py", line 887, in calibrate_petri
    loss = svi.step(method=method)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/svi.py", line 145, in step
    loss = self.loss_and_grads(self.model, self.guide, *args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/trace_elbo.py", line 140, in loss_and_grads
    for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/elbo.py", line 236, in _get_traces
    yield self._get_trace(model, guide, args, kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/trace_elbo.py", line 57, in _get_trace
    model_trace, guide_trace = get_importance_trace(
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/enum.py", line 60, in get_importance_trace
    guide_trace = poutine.trace(guide, graph_type=graph_type).get_trace(
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 198, in get_trace
    self(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 180, in __call__
    raise exc from e
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/poutine/trace_messenger.py", line 174, in __call__
    ret = self.fn(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 249, in forward
    result.update(part(*args, **kwargs))
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/nn/module.py", line 448, in __call__
    result = super().__call__(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 759, in forward
    self._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 999, in _setup_prototype
    super()._setup_prototype(*args, **kwargs)
  File "/Users/zuck016/.pyenv/versions/3.10.9/envs/pyciemss-main/lib/python3.10/site-packages/pyro/infer/autoguide/guides.py", line 654, in _setup_prototype
    raise RuntimeError(
RuntimeError: AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead
Trace Shapes:
 Param Sites:
Sample Sites:
=========================================================================================== short test summary info ============================================================================================
FAILED test/test_petrinet_ode/test_learnable_parameters.py::TestLearnableParameters::test_calibrate_fails_on_learned_parameters - RuntimeError: AutoLowRankMultivariateNormal found no latent variables; Use ...
============================================================================================== 1 failed in 34.24s ==============================================================================================
RuntimeError: : AutoLowRankMultivariateNormal found no latent variables; Use an empty guide instead
```