### PR TITLE
Support StockFlow example

### DIFF
--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -67,6 +67,9 @@ def _compile_param_values_mira(
     for param_info in src.parameters.values():
         param_name = get_name(param_info)
 
+        if param_info.placeholder:
+            continue
+
         param_dist = getattr(param_info, "distribution", None)
         if param_dist is None:
             param_value = param_info.value

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,7 +22,7 @@ REGNET_URLS = [
 ]
 
 STOCKFLOW_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json"
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json"
 ]
 
 MODEL_URLS = PETRI_URLS + REGNET_URLS + STOCKFLOW_URLS


### PR DESCRIPTION
This small PR ignores parameters that were previously placeholders, which caused a problem for the StockFlow example. In addition, we add back the StockFlow example to the test fixtures.