### PR TITLE
Support for regulatory networks

### DIFF
--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -50,7 +50,7 @@ def _compile_initial_state_mira(
     src: mira.modeling.Model,
 ) -> Callable[..., Tuple[torch.Tensor]]:
     symbolic_initials = {
-        get_name(var): src.template_model.initials[get_name(var)].expression.args[0]
+        get_name(var): src.variables[get_name(var)].data['expression'].args[0]
         for var in src.variables.values()
     }
     numeric_initial_state_func = sympytorch.SymPyModule(

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ license_files = LICENSE
 install_requires =
     jupyter
     torch >= 1.8.0
-    mira @ git+https://github.com/indralab/mira.git@0.2.0
+    mira @ git+https://github.com/indralab/mira.git@0.2.1
     chirho @ git+https://github.com/BasisResearch/chirho@f3019d4b22f4e49261efbf8da90a30095af2afbc
     sympytorch
     torchdiffeq

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,19 +10,19 @@ PETRI_URLS = [
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/flux_typed.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/flux_typed_aug.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/ont_pop_vax.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_flux_span.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed_aug.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed_aug.json",
 ]
 
 REGNET_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/syntax_edge_cases.json",
 ]
 
 STOCKFLOW_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json"
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json"
 ]
 
 MODEL_URLS = PETRI_URLS + REGNET_URLS + STOCKFLOW_URLS


### PR DESCRIPTION
This PR adds regulatory networks to our tests suite now that https://github.com/gyorilab/mira/pull/254 is resolved.