### PR TITLE
Remove package finding AND add to module exports (#407)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,3 +339,4 @@ venv/
 *~
 *_schema.json
 *data_with_missing_entries.csv
+*.nix

--- a/pyciemss/__init__.py
+++ b/pyciemss/__init__.py
@@ -1,1 +1,2 @@
-from .mira_integration import compiled_dynamics  # noqa: F401
+from pyciemss.interfaces import sample  # noqa: F401
+from pyciemss.mira_integration import compiled_dynamics  # noqa: F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,19 +18,13 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.8
 
-packages = find:
-
-package_dir =
-    = pyciemss
+packages = 
+    pyciemss
+    pyciemss.integration_utils
+    pyciemss.mira_integration
 
 [options.package_data]
 * = *.json
-
-
-[options.packages.find]
-
-where =
-    pyciemss
 
 
 [options.extras_require]


### PR DESCRIPTION
* Remove package finding AND add to module exports

* Clear out top-level `__init__.py`

* Reinclude explicit exports

* Include subpackages

* Skip incorrect lint error

* reorder imports for lint

* revert previous commit and add missing space before noqa

---------