### PR TITLE
Add observables to sample output

### DIFF
--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -35,6 +35,7 @@ class CompiledDynamics(pyro.nn.PyroModule):
         # Compile the numeric derivative of the model from the transition rate laws.
         setattr(self, "numeric_deriv_func", _compile_deriv(src))
         setattr(self, "numeric_initial_state_func", _compile_initial_state(src))
+        setattr(self, "numeric_observables_func", _compile_observables(src))
 
     @pyro.nn.pyro_method
     def deriv(self, X: State[torch.Tensor]) -> None:
@@ -43,6 +44,11 @@ class CompiledDynamics(pyro.nn.PyroModule):
     @pyro.nn.pyro_method
     def initial_state(self) -> State[torch.Tensor]:
         return eval_initial_state(self.src, self)
+
+    @pyro.nn.pyro_method
+    def add_observables(self, X: State[torch.Tensor]) -> State[torch.Tensor]:
+        observables = eval_observables(self.src, self, X)
+        return State(**X, **observables)
 
     def forward(
         self,
@@ -55,9 +61,11 @@ class CompiledDynamics(pyro.nn.PyroModule):
         for k in _compile_param_values(self.src).keys():
             getattr(self, get_name(k))
 
-        return simulate(
+        result = simulate(
             self.deriv, self.initial_state(), start_time, end_time, solver=solver
         )
+
+        return self.add_observables(result)
 
     @functools.singledispatchmethod
     @classmethod
@@ -98,6 +106,10 @@ def _compile_deriv(src) -> Callable[..., Tuple[torch.Tensor]]:
 def _compile_initial_state(src) -> Callable[..., Tuple[torch.Tensor]]:
     raise NotImplementedError
 
+@functools.singledispatch
+def _compile_observables(src) -> Callable[..., Tuple[torch.Tensor]]:
+    raise NotImplementedError
+
 
 @functools.singledispatch
 def _compile_param_values(
@@ -113,6 +125,11 @@ def eval_deriv(src, param_module: pyro.nn.PyroModule, X: State[T]) -> State[T]:
 
 @functools.singledispatch
 def eval_initial_state(src, param_module: pyro.nn.PyroModule) -> State[T]:
+    raise NotImplementedError
+
+
+@functools.singledispatch
+def eval_observables(src, param_module: pyro.nn.PyroModule, X: State[T]) -> State[T]:
     raise NotImplementedError
 
 

--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -106,6 +106,7 @@ def _compile_deriv(src) -> Callable[..., Tuple[torch.Tensor]]:
 def _compile_initial_state(src) -> Callable[..., Tuple[torch.Tensor]]:
     raise NotImplementedError
 
+
 @functools.singledispatch
 def _compile_observables(src) -> Callable[..., Tuple[torch.Tensor]]:
     raise NotImplementedError

--- a/pyciemss/integration_utils/result_processing.py
+++ b/pyciemss/integration_utils/result_processing.py
@@ -34,6 +34,7 @@ def convert_to_output_format(samples: Dict[str, torch.Tensor]) -> pd.DataFrame:
                 sample.data.detach().cpu().numpy().astype(np.float64)
             )
         else:
+            name = name + "_state"
             pyciemss_results["states"][name] = (
                 sample.data.detach().cpu().numpy().astype(np.float64)
             )

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -108,15 +108,18 @@ def sample(
                         torch.as_tensor(end_time),
                         TorchDiffEq(method=solver_method, options=solver_options),
                     )
+
+        trajectory = model.add_observables(lt.trajectory)
+
         # Adding deterministic nodes to the model so that we can access the trajectory in the Predictive object.
-        [pyro.deterministic(f"{k}_state", v) for k, v in lt.trajectory.items()]
+        [pyro.deterministic(k, v) for k, v in trajectory.items()]
 
         if noise_model is not None:
             compiled_noise_model = compile_noise_model(
-                noise_model, vars=set(lt.trajectory.keys()), **noise_model_kwargs
+                noise_model, vars=set(trajectory.keys()), **noise_model_kwargs
             )
             # Adding noise to the model so that we can access the noisy trajectory in the Predictive object.
-            compiled_noise_model(lt.trajectory)
+            compiled_noise_model(trajectory)
 
     samples = pyro.infer.Predictive(
         wrapped_model, guide=inferred_parameters, num_samples=num_samples

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -153,7 +153,6 @@ def _eval_observables_mira(
     param_module: pyro.nn.PyroModule,
     X: State[torch.Tensor],
 ) -> State[torch.Tensor]:
-    
     numeric_observables = param_module.numeric_observables_func(**X)
 
     observables = State()
@@ -178,11 +177,12 @@ def _get_name_mira_transition(trans: mira.modeling.Transition) -> str:
 def _get_name_mira_modelparameter(param: mira.modeling.ModelParameter) -> str:
     return str(param.key)
 
+
 @get_name.register
 def _get_name_mira_model_observable(obs: mira.modeling.ModelObservable) -> str:
     return obs.observable.name
 
+
 @get_name.register
 def _get_name_mira_observable(obs: mira.modeling.Observable) -> str:
     return obs.name
-

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numbers
-from typing import Callable, Dict, Tuple, TypeVar, Union
+from typing import Callable, Dict, Optional, Tuple, TypeVar, Union
 
 import mira
 import mira.metamodel
@@ -63,7 +63,10 @@ def _compile_initial_state_mira(
 @_compile_observables.register(mira.modeling.Model)
 def _compile_observables_mira(
     src: mira.modeling.Model,
-) -> Callable[..., Tuple[torch.Tensor]]:
+) -> Optional[Callable[..., Tuple[torch.Tensor]]]:
+    if len(src.observables) == 0:
+        return None
+
     symbolic_observables = {
         get_name(obs): obs.observable.expression.args[0]
         for obs in src.observables.values()
@@ -153,6 +156,9 @@ def _eval_observables_mira(
     param_module: pyro.nn.PyroModule,
     X: State[torch.Tensor],
 ) -> State[torch.Tensor]:
+    if len(src.observables) == 0:
+        return State()
+
     numeric_observables = param_module.numeric_observables_func(**X)
 
     observables = State()

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -18,9 +18,11 @@ from chirho.dynamical.ops import State
 from pyciemss.compiled_dynamics import (
     _compile_deriv,
     _compile_initial_state,
+    _compile_observables,
     _compile_param_values,
     eval_deriv,
     eval_initial_state,
+    eval_observables,
     get_name,
 )
 from pyciemss.mira_integration.distributions import mira_distribution_to_pyro
@@ -56,6 +58,23 @@ def _compile_initial_state_mira(
         expressions=[symbolic_initials[get_name(var)] for var in src.variables.values()]
     )
     return numeric_initial_state_func
+
+
+@_compile_observables.register(mira.modeling.Model)
+def _compile_observables_mira(
+    src: mira.modeling.Model,
+) -> Callable[..., Tuple[torch.Tensor]]:
+    symbolic_observables = {
+        get_name(obs): obs.observable.expression.args[0]
+        for obs in src.observables.values()
+    }
+
+    numeric_observables_func = sympytorch.SymPyModule(
+        expressions=[
+            symbolic_observables[get_name(obs)] for obs in src.observables.values()
+        ]
+    )
+    return numeric_observables_func
 
 
 @_compile_param_values.register(mira.modeling.Model)
@@ -128,6 +147,23 @@ def _eval_initial_state_mira(
     return X
 
 
+@eval_observables.register(mira.modeling.Model)
+def _eval_observables_mira(
+    src: mira.modeling.Model,
+    param_module: pyro.nn.PyroModule,
+    X: State[torch.Tensor],
+) -> State[torch.Tensor]:
+    
+    numeric_observables = param_module.numeric_observables_func(**X)
+
+    observables = State()
+    for i, obs in enumerate(src.observables.values()):
+        k = get_name(obs)
+        observables[k] = numeric_observables[i]
+
+    return observables
+
+
 @get_name.register
 def _get_name_mira_variable(var: mira.modeling.Variable) -> str:
     return var.data["name"]
@@ -141,3 +177,12 @@ def _get_name_mira_transition(trans: mira.modeling.Transition) -> str:
 @get_name.register
 def _get_name_mira_modelparameter(param: mira.modeling.ModelParameter) -> str:
     return str(param.key)
+
+@get_name.register
+def _get_name_mira_model_observable(obs: mira.modeling.ModelObservable) -> str:
+    return obs.observable.name
+
+@get_name.register
+def _get_name_mira_observable(obs: mira.modeling.Observable) -> str:
+    return obs.name
+

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -158,7 +158,7 @@ def _eval_observables_mira(
     observables = State()
     for i, obs in enumerate(src.observables.values()):
         k = get_name(obs)
-        observables[k] = numeric_observables[i]
+        observables[k] = numeric_observables[..., i]
 
     return observables
 

--- a/pyciemss/observation.py
+++ b/pyciemss/observation.py
@@ -29,7 +29,7 @@ class StateIndependentNoiseModel(NoiseModel):
     def forward(self, state: Dict[str, torch.Tensor]) -> None:
         for k in self.vars:
             pyro.sample(
-                f"{k}_observed",
+                f"{k}_noisy",
                 self.markov_kernel(k, state[k]),
             )
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,19 +10,19 @@ PETRI_URLS = [
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/flux_typed.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/flux_typed_aug.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/ont_pop_vax.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_flux_span.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed_aug.json",
 ]
 
 REGNET_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/syntax_edge_cases.json",
 ]
 
 STOCKFLOW_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json",
 ]
 
 MODEL_URLS = PETRI_URLS + REGNET_URLS + STOCKFLOW_URLS

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,17 +12,17 @@ PETRI_URLS = [
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/ont_pop_vax.json",
     "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_flux_span.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/petrinet/examples/sir_typed_aug.json",
 ]
 
 REGNET_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
     # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/syntax_edge_cases.json",
 ]
 
 STOCKFLOW_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json",
 ]
 
 MODEL_URLS = PETRI_URLS + REGNET_URLS + STOCKFLOW_URLS

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,13 +40,11 @@ def check_keys_match(obj1: Dict[str, T], obj2: Dict[str, T]):
     return True
 
 
-def check_states_match(
-    traj1: Dict[str, torch.Tensor], traj2: Dict[str, torch.Tensor], postfix="state"
-):
+def check_states_match(traj1: Dict[str, torch.Tensor], traj2: Dict[str, torch.Tensor]):
     assert check_keys_match(traj1, traj2)
 
-    for k in traj1.keys():
-        if k[-len(postfix) :] == postfix:
+    for k, val in traj1.items():
+        if val.ndim == 2:
             assert torch.allclose(
                 traj2[k], traj1[k]
             ), f"Trajectories differ in state trajectory of variable {k}."
@@ -55,12 +53,12 @@ def check_states_match(
 
 
 def check_states_match_in_all_but_values(
-    traj1: Dict[str, torch.Tensor], traj2: Dict[str, torch.Tensor], postfix="state"
+    traj1: Dict[str, torch.Tensor], traj2: Dict[str, torch.Tensor]
 ):
     assert check_keys_match(traj1, traj2)
 
-    for k in traj1.keys():
-        if k[-len(postfix) :] == postfix:
+    for k, val in traj1.items():
+        if val.ndim == 2:
             assert not torch.allclose(
                 traj2[k], traj1[k]
             ), f"Trajectories are identical in state trajectory of variable {k}, but should differ."
@@ -79,15 +77,12 @@ def check_result_sizes(
         assert isinstance(k, str)
         assert isinstance(v, torch.Tensor)
 
-        if k[-5:] == "state" or k[-8:] == "observed":
-            assert v.shape == (
-                num_samples,
-                len(
-                    torch.arange(
-                        start_time + logging_step_size, end_time, logging_step_size
-                    )
-                ),
-            )
+        num_timesteps = len(
+            torch.arange(start_time + logging_step_size, end_time, logging_step_size)
+        )
+
+        if v.ndim == 2:
+            assert v.shape == (num_samples, num_timesteps)
         else:
             assert v.shape == (num_samples,)
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -88,9 +88,9 @@ def test_sample_with_noise(
 
     for k in result.keys():
         if k[-5:] == "state":
-            observed = result[f"{k[:-6]}_noisy"]
+            noisy = result[f"{k[:-6]}_noisy"]
             state = result[k]
-            assert 0.5 * scale < torch.std(observed / state - 1) < 2 * scale
+            assert 0.5 * scale < torch.std(noisy / state - 1) < 2 * scale
 
 
 @pytest.mark.parametrize("model_url", MODEL_URLS)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -88,7 +88,7 @@ def test_sample_with_noise(
 
     for k in result.keys():
         if k[-5:] == "state":
-            observed = result[f"{k[:-6]}_observed"]
+            observed = result[f"{k[:-6]}_noisy"]
             state = result[k]
             assert 0.5 * scale < torch.std(observed / state - 1) < 2 * scale
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -308,7 +308,7 @@ def test_output_format(url, start_time, end_time, logging_step_size, num_samples
     assert processed_result.shape[1] >= 2
     assert list(processed_result.columns)[:2] == ["timepoint_id", "sample_id"]
     for col_name in processed_result.columns[2:]:
-        assert col_name.split("_")[-1] in ("param", "state", "(unknown)")
+        assert col_name.split("_")[-1] in ("param", "state")
         assert processed_result[col_name].dtype == np.float64
 
     assert processed_result["timepoint_id"].dtype == np.int64


### PR DESCRIPTION
This PR adds `observables` to the output of the `sample` interface when it exists.

~~Note: this PR is currently blocked by not having any up-to-date AMRs that contain both observables, and numerically stable parameterizations.~~

~~blocked by #411 , as we'd like to add observables to ensemble models as well.~~

~~blocked by #415~~