### PR TITLE
Bump ChiRho version in dependencies and update any changes resulting from API changes

### DIFF
--- a/docs/source/interfaces.ipynb
+++ b/docs/source/interfaces.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "### SETUP ###\n",
     "\n",
-    "model_1_path = \"https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json\"\n",
+    "model_1_path = \"https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type1_petrinet.json\"\n",
     "start_time = 0.0\n",
     "end_time = 100.\n",
     "logging_step_size = 10.0\n",
@@ -252,7 +252,7 @@
    "outputs": [],
    "source": [
     "### ENSEMBLE SETUP ###\n",
-    "model_2_path = \"https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json\""
+    "model_2_path = \"https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type2_petrinet.json\""
    ]
   },
   {

--- a/pyciemss/ensemble/compiled_dynamics.py
+++ b/pyciemss/ensemble/compiled_dynamics.py
@@ -5,7 +5,6 @@ from typing import Callable, Dict, List, TypeVar
 
 import pyro
 import torch
-from chirho.dynamical.handlers.solver import Solver, TorchDiffEq
 from chirho.dynamical.ops import State
 from pyro.contrib.autoname import scope
 
@@ -37,7 +36,7 @@ class EnsembleCompiledDynamics(pyro.nn.PyroModule):
         start_time: torch.Tensor,
         end_time: torch.Tensor,
     ) -> State[torch.Tensor]:
-        solutions = [dict()] * len(self.dynamics_models)
+        solutions: List[State[torch.Tensor]] = [dict()] * len(self.dynamics_models)
         for i, dynamics in enumerate(self.dynamics_models):
             with scope(prefix=f"model_{i}"):
                 solutions[i] = dynamics(start_time, end_time)

--- a/pyciemss/ensemble/compiled_dynamics.py
+++ b/pyciemss/ensemble/compiled_dynamics.py
@@ -36,14 +36,13 @@ class EnsembleCompiledDynamics(pyro.nn.PyroModule):
         self,
         start_time: torch.Tensor,
         end_time: torch.Tensor,
-        solver: Solver = TorchDiffEq(),
     ) -> State[torch.Tensor]:
-        solutions = [State()] * len(self.dynamics_models)
+        solutions = [dict()] * len(self.dynamics_models)
         for i, dynamics in enumerate(self.dynamics_models):
             with scope(prefix=f"model_{i}"):
-                solutions[i] = dynamics(start_time, end_time, solver)
+                solutions[i] = dynamics(start_time, end_time)
 
-        return State(
+        return dict(
             **{
                 k: sum([self.model_weights[i] * v[k] for i, v in enumerate(solutions)])
                 for k in solutions[0].keys()

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -24,7 +24,7 @@ from pyciemss.integration_utils.result_processing import prepare_interchange_dic
 @pyciemss_logging_wrapper
 def ensemble_sample(
     model_paths_or_jsons: List[Union[str, Dict]],
-    solution_mappings: List[Callable[[State[torch.Tensor]], State[torch.Tensor]]],
+    solution_mappings: List[Callable[[Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]],
     end_time: float,
     logging_step_size: float,
     num_samples: int,
@@ -44,7 +44,7 @@ def ensemble_sample(
     Args:
     model_paths_or_jsons: List[Union[str, Dict]]
         - A list of paths to AMR model files or JSONs containing models in AMR form.
-    solution_mappings: List[Callable[[State[torch.Tensor]], State[torch.Tensor]]]
+    solution_mappings: List[Callable[[Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]]
         - A list of functions that map the solution of each model to a common solution space.
         - Each function takes in a dictionary of the form {state_variable_name: value}
             and returns a dictionary of the same form.
@@ -79,7 +79,7 @@ def ensemble_sample(
         - If not provided, we will use the default values from the AMR model.
 
     Returns:
-        result: State[torch.Tensor]
+        result: Dict[str, torch.Tensor]
             - Dictionary of outputs from the model.
                 - Each key is the name of a parameter or state variable in the model.
                 - Each value is a tensor of shape (num_samples, num_timepoints) for state variables
@@ -150,11 +150,11 @@ def sample(
     solver_options: Dict[str, Any] = {},
     start_time: float = 0.0,
     inferred_parameters: Optional[pyro.nn.PyroModule] = None,
-    static_interventions: Dict[float, State[torch.Tensor]] = {},
+    static_interventions: Dict[float, Dict[str, torch.Tensor]] = {},
     dynamic_interventions: Dict[
-        Callable[[State[torch.Tensor]], torch.Tensor], State[torch.Tensor]
+        Callable[[Dict[str, torch.Tensor]], torch.Tensor], Dict[str, torch.Tensor]
     ] = {},
-) -> State[torch.Tensor]:
+) -> Dict[str, torch.Tensor]:
     """
     Load a model from a file, compile it into a probabilistic program, and sample from it.
 
@@ -181,18 +181,18 @@ def sample(
             - A Pyro module that contains the inferred parameters of the model.
               This is typically the result of `calibrate`.
             - If not provided, we will use the default values from the AMR model.
-        static_interventions: Dict[float, State[torch.Tensor]]
+        static_interventions: Dict[float, Dict[str, torch.Tensor]]
             - A dictionary of static interventions to apply to the model.
             - Each key is the time at which the intervention is applied.
             - Each value is a dictionary of the form {state_variable_name: value}.
-        dynamic_interventions: Dict[Callable[[State[torch.Tensor]], torch.Tensor], State[torch.Tensor]]
+        dynamic_interventions: Dict[Callable[[Dict[str, torch.Tensor]], torch.Tensor], Dict[str, torch.Tensor]]
             - A dictionary of dynamic interventions to apply to the model.
             - Each key is a function that takes in the current state of the model and returns a tensor.
               When this function crosses 0, the dynamic intervention is applied.
             - Each value is a dictionary of the form {state_variable_name: value}.
 
     Returns:
-        result: State[torch.Tensor]
+        result: Dict[str, torch.Tensor]
             - Dictionary of outputs from the model.
                 - Each key is the name of a parameter or state variable in the model.
                 - Each value is a tensor of shape (num_samples, num_timepoints) for state variables
@@ -243,7 +243,7 @@ def sample(
 
 def calibrate(
     model_path_or_json: Union[str, Dict],
-    data: State[torch.Tensor],
+    data: Dict[str, torch.Tensor],
     data_timepoints: torch.Tensor,
     *,
     noise_model: str = "normal",
@@ -251,9 +251,9 @@ def calibrate(
     solver_method: str = "dopri5",
     solver_options: Dict[str, Any] = {},
     start_time: float = 0.0,
-    static_interventions: Dict[float, State[torch.Tensor]] = {},
+    static_interventions: Dict[float, Dict[str, torch.Tensor]] = {},
     dynamic_interventions: Dict[
-        Callable[[State[torch.Tensor]], torch.Tensor], State[torch.Tensor]
+        Callable[[Dict[str, torch.Tensor]], torch.Tensor], Dict[str, torch.Tensor]
     ] = {},
     num_iterations: int = 1000,
     lr: float = 0.03,
@@ -268,7 +268,7 @@ def calibrate(
     Args:
         - model_path_or_json: Union[str, Dict]
             - A path to a AMR model file or JSON containing a model in AMR form.
-        - data: State[torch.Tensor]
+        - data: Dict[str, torch.Tensor]
             - A dictionary of data to condition the model on.
             - Each key is the name of a state variable in the model.
             - Each value is a tensor of shape (num_timepoints,) for state variables.
@@ -290,11 +290,11 @@ def calibrate(
             - The start time of the model. This is used to align the `start_state` from the
               AMR model with the simulation timepoints.
             - By default we set the `start_time` to be 0.
-        - static_interventions: Dict[float, State[torch.Tensor]]
+        - static_interventions: Dict[float, Dict[str, torch.Tensor]]
             - A dictionary of static interventions to apply to the model.
             - Each key is the time at which the intervention is applied.
             - Each value is a dictionary of the form {state_variable_name: value}.
-        - dynamic_interventions: Dict[Callable[[State[torch.Tensor]], torch.Tensor], State[torch.Tensor]]
+        - dynamic_interventions: Dict[Callable[[Dict[str, torch.Tensor]], torch.Tensor], Dict[str, torch.Tensor]]
             - A dictionary of dynamic interventions to apply to the model.
             - Each key is a function that takes in the current state of the model and returns a tensor.
               When this function crosses 0, the dynamic intervention is applied.

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -24,7 +24,9 @@ from pyciemss.integration_utils.result_processing import prepare_interchange_dic
 @pyciemss_logging_wrapper
 def ensemble_sample(
     model_paths_or_jsons: List[Union[str, Dict]],
-    solution_mappings: List[Callable[[Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]],
+    solution_mappings: List[
+        Callable[[Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
+    ],
     end_time: float,
     logging_step_size: float,
     num_samples: int,

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -24,9 +24,7 @@ from pyciemss.integration_utils.result_processing import prepare_interchange_dic
 @pyciemss_logging_wrapper
 def ensemble_sample(
     model_paths_or_jsons: List[Union[str, Dict]],
-    solution_mappings: List[
-        Callable[[State[torch.Tensor]], State[torch.Tensor]]
-    ],
+    solution_mappings: List[Callable[[State[torch.Tensor]], State[torch.Tensor]]],
     end_time: float,
     logging_step_size: float,
     num_samples: int,
@@ -110,8 +108,11 @@ def ensemble_sample(
 
                     solutions[i] = lt.trajectory
 
-                    # Adding deterministic nodes to the model so that we can access the trajectory in the Predictive object.
-                    [pyro.deterministic(f"{k}_state", v) for k, v in lt.trajectory.items()]
+                    # Adding deterministic nodes to the model so that we can access the trajectory in the trace.
+                    [
+                        pyro.deterministic(f"{k}_state", v)
+                        for k, v in lt.trajectory.items()
+                    ]
 
                     if noise_model is not None:
                         compiled_noise_model = compile_noise_model(

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -120,7 +120,7 @@ def ensemble_sample(
                             vars=set(lt.trajectory.keys()),
                             **noise_model_kwargs,
                         )
-                        # Adding noise to the model so that we can access the noisy trajectory in the Predictive object.
+                        # Adding noise to the model so that we can access the noisy trajectory in the trace.
                         compiled_noise_model(lt.trajectory)
 
         return dict(

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -98,7 +98,7 @@ def ensemble_sample(
         # We need to interleave the LogTrajectory and the solutions from the models.
         # This because each contituent model will have its own LogTrajectory.
 
-        solutions = [dict()] * len(model_paths_or_jsons)
+        solutions: List[State[torch.Tensor]] = [dict()] * len(model_paths_or_jsons)
 
         for i, dynamics in enumerate(model.dynamics_models):
             with TorchDiffEq(method=solver_method, options=solver_options):

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -123,7 +123,7 @@ def _eval_deriv_mira(
 
     numeric_deriv = param_module.numeric_deriv_func(**X, **parameters)
 
-    dX = State()
+    dX: State[torch.Tensor] = dict()
     for i, var in enumerate(src.variables.values()):
         k = get_name(var)
         dX[k] = numeric_deriv[i]
@@ -143,7 +143,7 @@ def _eval_initial_state_mira(
 
     numeric_initial_state = param_module.numeric_initial_state_func(**parameters)
 
-    X = State()
+    X: State[torch.Tensor] = dict()
     for i, var in enumerate(src.variables.values()):
         k = get_name(var)
         X[k] = numeric_initial_state[i]
@@ -157,11 +157,11 @@ def _eval_observables_mira(
     X: State[torch.Tensor],
 ) -> State[torch.Tensor]:
     if len(src.observables) == 0:
-        return State()
+        return dict()
 
     numeric_observables = param_module.numeric_observables_func(**X)
 
-    observables = State()
+    observables: State[torch.Tensor] = dict()
     for i, obs in enumerate(src.observables.values()):
         k = get_name(obs)
         observables[k] = numeric_observables[..., i]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ install_requires =
     jupyter
     torch >= 1.8.0
     mira @ git+https://github.com/indralab/mira.git@0.2.1
-    chirho @ git+https://github.com/BasisResearch/chirho@f3019d4b22f4e49261efbf8da90a30095af2afbc
+    chirho[dynamical] == 0.2.0
     sympytorch
     torchdiffeq
     pandas

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,17 +8,17 @@ T = TypeVar("T")
 # See https://github.com/DARPA-ASKEM/Model-Representations/issues/62 for discussion of valid models.
 
 PETRI_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
 ]
 
 REGNET_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
 ]
 
 STOCKFLOW_URLS = [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,17 +7,17 @@ T = TypeVar("T")
 # See https://github.com/DARPA-ASKEM/Model-Representations/issues/62 for discussion of valid models.
 
 PETRI_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
 ]
 
 REGNET_URLS = [
-    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
 ]
 
 STOCKFLOW_URLS = [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -88,6 +88,7 @@ def check_result_sizes(
 
     return True
 
+
 def check_is_state(state: torch.Tensor, value_type):
     assert isinstance(state, Mapping)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,17 +7,17 @@ T = TypeVar("T")
 # See https://github.com/DARPA-ASKEM/Model-Representations/issues/62 for discussion of valid models.
 
 PETRI_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
 ]
 
 REGNET_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
 ]
 
 STOCKFLOW_URLS = [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,13 +8,11 @@ T = TypeVar("T")
 # See https://github.com/DARPA-ASKEM/Model-Representations/issues/62 for discussion of valid models.
 
 PETRI_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRD_base_model01_petrinet.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type1_petrinet.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type2_petrinet.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_base_model01_petrinet.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_with_reinfection01_petrinet.json",  # noqa: E501
 ]
 
 REGNET_URLS = [
@@ -22,7 +20,11 @@ REGNET_URLS = [
 ]
 
 STOCKFLOW_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/stockflow/examples/sir.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRD_stockflow.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHDS_stockflow.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_stockflow.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIR_stockflow.json",  # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SIR_stockflow.json",  # noqa: E501
 ]
 
 MODEL_URLS = PETRI_URLS + REGNET_URLS + STOCKFLOW_URLS

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Dict, TypeVar
 
 import torch
@@ -7,17 +8,17 @@ T = TypeVar("T")
 # See https://github.com/DARPA-ASKEM/Model-Representations/issues/62 for discussion of valid models.
 
 PETRI_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRD_base_model01.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type1.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_NPI_Type2.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_base_model01.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_three_beta.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_two_beta.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/raw_models/SEIRHD_with_reinfection01.json",  # noqa: E501
 ]
 
 REGNET_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    # "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
 ]
 
 STOCKFLOW_URLS = [
@@ -84,5 +85,14 @@ def check_result_sizes(
             assert v.shape == (num_samples, num_timesteps)
         else:
             assert v.shape == (num_samples,)
+
+    return True
+
+def check_is_state(state: torch.Tensor, value_type):
+    assert isinstance(state, Mapping)
+
+    assert all(isinstance(key, str) for key in state.keys())
+
+    assert all(isinstance(value, value_type) for value in state.values())
 
     return True

--- a/tests/test_compiled_dynamics.py
+++ b/tests/test_compiled_dynamics.py
@@ -4,11 +4,11 @@ import tempfile
 import pytest
 import requests
 import torch
-from chirho.dynamical.ops import State
+from chirho.dynamical.handlers.solver import TorchDiffEq
 
 from pyciemss.compiled_dynamics import CompiledDynamics
 
-from .fixtures import END_TIMES, MODEL_URLS, START_TIMES
+from .fixtures import END_TIMES, MODEL_URLS, START_TIMES, check_is_state
 
 
 @pytest.mark.parametrize("url", MODEL_URLS)
@@ -17,9 +17,10 @@ from .fixtures import END_TIMES, MODEL_URLS, START_TIMES
 def test_compiled_dynamics_load_url(url, start_time, end_time):
     model = CompiledDynamics.load(url)
     assert isinstance(model, CompiledDynamics)
-
-    simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
-    assert isinstance(simulation, State)
+    
+    with TorchDiffEq():
+        simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
+    check_is_state(simulation, torch.Tensor)
 
 
 @pytest.mark.parametrize("url", MODEL_URLS)
@@ -35,8 +36,9 @@ def test_compiled_dynamics_load_path(url, start_time, end_time):
         model = CompiledDynamics.load(tf.name)
     assert isinstance(model, CompiledDynamics)
 
-    simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
-    assert isinstance(simulation, State)
+    with TorchDiffEq():
+        simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
+    check_is_state(simulation, torch.Tensor)
 
 
 @pytest.mark.parametrize("url", MODEL_URLS)
@@ -50,5 +52,6 @@ def test_compiled_dynamics_load_json(url, start_time, end_time):
     model = CompiledDynamics.load(model_json)
     assert isinstance(model, CompiledDynamics)
 
-    simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
-    assert isinstance(simulation, State)
+    with TorchDiffEq():
+        simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
+    check_is_state(simulation, torch.Tensor)

--- a/tests/test_compiled_dynamics.py
+++ b/tests/test_compiled_dynamics.py
@@ -17,7 +17,7 @@ from .fixtures import END_TIMES, MODEL_URLS, START_TIMES, check_is_state
 def test_compiled_dynamics_load_url(url, start_time, end_time):
     model = CompiledDynamics.load(url)
     assert isinstance(model, CompiledDynamics)
-    
+
     with TorchDiffEq():
         simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
     check_is_state(simulation, torch.Tensor)

--- a/tests/test_ensemble_compiled_dynamics.py
+++ b/tests/test_ensemble_compiled_dynamics.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
+from chirho.dynamical.handlers.solver import TorchDiffEq
 
 from pyciemss.ensemble.compiled_dynamics import EnsembleCompiledDynamics
-from chirho.dynamical.handlers.solver import TorchDiffEq
 
 from .fixtures import END_TIMES, MODEL_URLS, START_TIMES, check_is_state
 

--- a/tests/test_ensemble_compiled_dynamics.py
+++ b/tests/test_ensemble_compiled_dynamics.py
@@ -1,10 +1,10 @@
 import pytest
 import torch
-from chirho.dynamical.ops import State
 
 from pyciemss.ensemble.compiled_dynamics import EnsembleCompiledDynamics
+from chirho.dynamical.handlers.solver import TorchDiffEq
 
-from .fixtures import END_TIMES, MODEL_URLS, START_TIMES
+from .fixtures import END_TIMES, MODEL_URLS, START_TIMES, check_is_state
 
 
 @pytest.mark.parametrize("url", MODEL_URLS)
@@ -18,6 +18,6 @@ def test_ensemble_compiled_dynamics_load_url(url, start_time, end_time):
         [lambda x: x, lambda x: {k: 2 * v for k, v in x.items()}],
     )
     assert isinstance(model, EnsembleCompiledDynamics)
-
-    simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
-    assert isinstance(simulation, State)
+    with TorchDiffEq():
+        simulation = model(torch.as_tensor(start_time), torch.as_tensor(end_time))
+    check_is_state(simulation, torch.Tensor)


### PR DESCRIPTION
This PR bumps ChiRho to use v0.2.0 and resolves any changes to the API that are necessary to accomplish this.