### PR TITLE
Adding regnet urls to fixtures, and limiting number of examples to three per type

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -26,8 +26,12 @@ PETRI_MODELS = [
 ]
 
 REGNET_MODELS = [
-    ModelFixture(os.path.join(MODELS_PATH, "LV_rabbits_wolves_model02_regnet.json"), "beta"),
-    ModelFixture(os.path.join(MODELS_PATH, "LV_rabbits_wolves_model03_regnet.json"), "beta"),
+    ModelFixture(
+        os.path.join(MODELS_PATH, "LV_rabbits_wolves_model02_regnet.json"), "beta"
+    ),
+    ModelFixture(
+        os.path.join(MODELS_PATH, "LV_rabbits_wolves_model03_regnet.json"), "beta"
+    ),
     ModelFixture(os.path.join(MODELS_PATH, "LV_goat_chupacabra_regnet.json"), "beta"),
 ]
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,23 +8,21 @@ T = TypeVar("T")
 # See https://github.com/DARPA-ASKEM/Model-Representations/issues/62 for discussion of valid models.
 
 PETRI_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRD_base_model01_petrinet.json",  # noqa: E501
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type1_petrinet.json",  # noqa: E501
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type2_petrinet.json",  # noqa: E501
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_base_model01_petrinet.json",  # noqa: E501
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_with_reinfection01_petrinet.json",  # noqa: E501
 ]
 
 REGNET_URLS = [
-    "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/main/regnet/examples/lotka_volterra.json",
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/LV_rabbits_wolves_model02_regnet.json", # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/LV_rabbits_wolves_model03_regnet.json", # noqa: E501
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/LV_goat_chupacabra_regnet.json", # noqa: E501
 ]
 
 STOCKFLOW_URLS = [
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRD_stockflow.json",  # noqa: E501
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHDS_stockflow.json",  # noqa: E501
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_stockflow.json",  # noqa: E501
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIR_stockflow.json",  # noqa: E501
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SIR_stockflow.json",  # noqa: E501
 ]
 
 MODEL_URLS = PETRI_URLS + REGNET_URLS + STOCKFLOW_URLS

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,8 +8,8 @@ T = TypeVar("T")
 # See https://github.com/DARPA-ASKEM/Model-Representations/issues/62 for discussion of valid models.
 
 PETRI_URLS = [
+    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type1_petrinet.json",  # noqa: E501
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_NPI_Type2_petrinet.json",  # noqa: E501
-    "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_base_model01_petrinet.json",  # noqa: E501
     "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIRHD_with_reinfection01_petrinet.json",  # noqa: E501
 ]
 


### PR DESCRIPTION
This PR adds three regnet examples and deletes two petrinet and two stockflow amr example url to `fixtures.py`.