### PR TITLE
Add parameter interventions to calibrate and refactor interface tests

### DIFF
--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -47,9 +47,8 @@ class CompiledDynamics(pyro.nn.PyroModule):
         return eval_initial_state(self.src, self)
 
     @pyro.nn.pyro_method
-    def add_observables(self, X: State[torch.Tensor]) -> State[torch.Tensor]:
-        observables = eval_observables(self.src, self, X)
-        return dict(**X, **observables)
+    def observables(self, X: State[torch.Tensor]) -> State[torch.Tensor]:
+        return eval_observables(self.src, self, X)
 
     @pyro.nn.pyro_method
     def instantiate_parameters(self):
@@ -70,9 +69,11 @@ class CompiledDynamics(pyro.nn.PyroModule):
     ):
         self.instantiate_parameters()
 
-        result = simulate(self.deriv, self.initial_state(), start_time, end_time)
+        state = simulate(self.deriv, self.initial_state(), start_time, end_time)
 
-        return self.add_observables(result)
+        observables = self.observables(state)
+
+        return {**state, **observables}
 
     @functools.singledispatchmethod
     @classmethod

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -29,9 +29,9 @@ REGNET_MODELS = [
     ModelFixture(
         os.path.join(MODELS_PATH, "LV_rabbits_wolves_model02_regnet.json"), "beta"
     ),
-    # ModelFixture(
-    #     os.path.join(MODELS_PATH, "LV_rabbits_wolves_model03_regnet.json"), "beta"
-    # ),
+    ModelFixture(
+        os.path.join(MODELS_PATH, "LV_rabbits_wolves_model03_regnet.json"), "beta"
+    ),
     ModelFixture(os.path.join(MODELS_PATH, "LV_goat_chupacabra_regnet.json"), "beta"),
 ]
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -29,9 +29,9 @@ REGNET_MODELS = [
     ModelFixture(
         os.path.join(MODELS_PATH, "LV_rabbits_wolves_model02_regnet.json"), "beta"
     ),
-    ModelFixture(
-        os.path.join(MODELS_PATH, "LV_rabbits_wolves_model03_regnet.json"), "beta"
-    ),
+    # ModelFixture(
+    #     os.path.join(MODELS_PATH, "LV_rabbits_wolves_model03_regnet.json"), "beta"
+    # ),
     ModelFixture(os.path.join(MODELS_PATH, "LV_goat_chupacabra_regnet.json"), "beta"),
 ]
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -309,11 +309,10 @@ def test_calibrate_interventions(
 
     if intervention_target == "state":
         initial_state = model.initial_state()
-        intervention = {k: v.detach() + 1 for k, v in initial_state.items()}
+        intervention = {k: (lambda x: 0.9 * x) for k in initial_state.keys()}
     elif intervention_target == "parameter":
         important_parameter_name = model_fixture.important_parameter
-        important_parameter = getattr(model, important_parameter_name)
-        intervention = {important_parameter_name: important_parameter.detach() + 1}
+        intervention = {important_parameter_name: (lambda x: 0.9 * x)}
 
     if intervention_type == "static":
         time_key = intervention_time

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -26,9 +26,37 @@ def dummy_ensemble_sample(model_path_or_json, *args, **kwargs):
     return ensemble_sample(model_paths_or_jsons, solution_mappings, *args, **kwargs)
 
 
+def setup_calibrate(model_url, start_time, end_time, logging_step_size):
+    sample_args = [model_url, end_time, logging_step_size, 1]
+
+    sample_kwargs = {
+        "start_time": start_time,
+    }
+
+    result = sample(*sample_args, **sample_kwargs)["unprocessed_result"]
+
+    data = {
+        k[:-6]: v.squeeze().detach() for k, v in result.items() if k[-5:] == "state"
+    }
+
+    data_timespan = torch.arange(
+        start_time + logging_step_size, end_time, logging_step_size
+    )
+
+    parameter_names = [k for k, v in result.items() if v.ndim == 1]
+
+    return data, data_timespan, parameter_names, sample_args, sample_kwargs
+
+
 SAMPLE_METHODS = [sample, dummy_ensemble_sample]
 INTERVENTION_TYPES = ["static", "dynamic"]
 INTERVENTION_TARGETS = ["state", "parameter"]
+
+CALIBRATE_KWARGS = {
+    "noise_model": "normal",
+    "noise_model_kwargs": {"scale": 1.0},
+    "num_iterations": 2,
+}
 
 
 @pytest.mark.parametrize("sample_method", SAMPLE_METHODS)
@@ -101,90 +129,61 @@ def test_sample_with_noise(
 @pytest.mark.parametrize("end_time", END_TIMES)
 @pytest.mark.parametrize("logging_step_size", LOGGING_STEP_SIZES)
 @pytest.mark.parametrize("num_samples", NUM_SAMPLES)
-@pytest.mark.parametrize("intervention_1_type", INTERVENTION_TYPES)
-@pytest.mark.parametrize("intervention_1_target", INTERVENTION_TARGETS)
-@pytest.mark.parametrize("intervention_2_type", INTERVENTION_TYPES + [None])
-@pytest.mark.parametrize("intervention_2_target", INTERVENTION_TARGETS)
+@pytest.mark.parametrize("intervention_type", INTERVENTION_TYPES)
+@pytest.mark.parametrize("intervention_target", INTERVENTION_TARGETS)
 def test_sample_with_interventions(
     model_fixture,
     start_time,
     end_time,
     logging_step_size,
     num_samples,
-    intervention_1_type,
-    intervention_1_target,
-    intervention_2_type,
-    intervention_2_target,
+    intervention_type,
+    intervention_target,
 ):
     model_url = model_fixture.url
     model = CompiledDynamics.load(model_url)
-
-    intervention_time_1 = (end_time + start_time) / 2  # Midpoint
-    intervention_time_2 = (end_time + intervention_time_1) / 2  # 3/4 point
-
-    # Same intervention time expressed as an event function
-    def intervention_event_fn_1(time: torch.Tensor, *args, **kwargs):
-        return time - intervention_time_1
-
-    def intervention_event_fn_2(time: torch.Tensor, *args, **kwargs):
-        return time - intervention_time_2
-
-    static_state_interventions = {}
-    static_parameter_interventions = {}
-    dynamic_state_interventions = {}
-    dynamic_parameter_interventions = {}
 
     initial_state = model.initial_state()
     important_parameter_name = model_fixture.important_parameter
     important_parameter = getattr(model, important_parameter_name)
 
-    if intervention_1_target == "state":
-        intervened_state_1 = {k: v + 1 for k, v in initial_state.items()}
-        if intervention_1_type == "static":
-            static_state_interventions[intervention_time_1] = intervened_state_1
-        elif intervention_1_type == "dynamic":
-            dynamic_state_interventions[intervention_event_fn_1] = intervened_state_1
-    elif intervention_1_target == "parameter":
-        intervened_state_1 = {important_parameter_name: important_parameter + 1}
-        if intervention_1_type == "static":
-            static_parameter_interventions[intervention_time_1] = intervened_state_1
-        elif intervention_1_type == "dynamic":
-            dynamic_parameter_interventions[
-                intervention_event_fn_1
-            ] = intervened_state_1
+    intervention_effect = 1.0
+    intervention_time = (end_time + start_time) / 4  # Quarter of the way through
 
-    if intervention_2_target == "state":
-        intervened_state_2 = {k: (lambda v: v + 2) for k in initial_state.keys()}
-        if intervention_2_type == "static":
-            static_state_interventions[intervention_time_2] = intervened_state_2
-        elif intervention_2_type == "dynamic":
-            dynamic_state_interventions[intervention_event_fn_2] = intervened_state_2
-    elif intervention_2_target == "parameter":
-        intervened_state_2 = {important_parameter_name: (lambda x: x + 2)}
-        if intervention_2_type == "static":
-            static_parameter_interventions[intervention_time_2] = intervened_state_2
-        elif intervention_2_type == "dynamic":
-            dynamic_parameter_interventions[
-                intervention_event_fn_2
-            ] = intervened_state_2
+    if intervention_target == "state":
+        intervention = {
+            k: v.detach() + intervention_effect for k, v in initial_state.items()
+        }
+    elif intervention_target == "parameter":
+        intervention = {
+            important_parameter_name: important_parameter.detach() + intervention_effect
+        }
+
+    if intervention_type == "static":
+        time_key = intervention_time
+    elif intervention_type == "dynamic":
+        # Same intervention time expressed as an event function
+        def time_key(time, _):
+            return time - intervention_time
+
+    interventions_kwargs = {
+        f"{intervention_type}_{intervention_target}_interventions": {
+            time_key: intervention
+        }
+    }
+
+    model_args = [model_url, end_time, logging_step_size, num_samples]
+    model_kwargs = {"start_time": start_time}
 
     with pyro.poutine.seed(rng_seed=0):
         intervened_result = sample(
-            model_url,
-            end_time,
-            logging_step_size,
-            num_samples,
-            start_time=start_time,
-            static_state_interventions=static_state_interventions,
-            static_parameter_interventions=static_parameter_interventions,
-            dynamic_state_interventions=dynamic_state_interventions,
-            dynamic_parameter_interventions=dynamic_parameter_interventions,
+            *model_args,
+            **model_kwargs,
+            **interventions_kwargs,
         )["unprocessed_result"]
 
     with pyro.poutine.seed(rng_seed=0):
-        result = sample(
-            model_url, end_time, logging_step_size, num_samples, start_time=start_time
-        )["unprocessed_result"]
+        result = sample(*model_args, **model_kwargs)["unprocessed_result"]
 
     check_states_match_in_all_but_values(result, intervened_result)
     check_result_sizes(result, start_time, end_time, logging_step_size, num_samples)
@@ -197,79 +196,148 @@ def test_sample_with_interventions(
 @pytest.mark.parametrize("start_time", START_TIMES)
 @pytest.mark.parametrize("end_time", END_TIMES)
 @pytest.mark.parametrize("logging_step_size", LOGGING_STEP_SIZES)
-def test_calibrate_and_sample(model_url, start_time, end_time, logging_step_size):
-    result = sample(
-        model_url,
-        end_time,
-        logging_step_size,
-        1,
-        start_time=start_time,
-    )["unprocessed_result"]
-
-    data = {k[:-6]: v.squeeze() for k, v in result.items() if k[-5:] == "state"}
-    parameter_names = [k for k in result.keys() if k[-5:] != "state"]
-
-    data_timespan = torch.arange(
-        start_time + logging_step_size, end_time, logging_step_size
+def test_calibrate_no_kwargs(model_url, start_time, end_time, logging_step_size):
+    data, data_timespan, _, sample_args, sample_kwargs = setup_calibrate(
+        model_url, start_time, end_time, logging_step_size
     )
 
-    inferred_parameters_1 = calibrate(
-        model_url,
-        data,
-        data_timespan,
-        start_time=start_time,
-        noise_model="normal",
-        noise_model_kwargs={"scale": 1.0},
-        num_iterations=2,
-    )
+    calibrate_args = [model_url, data, data_timespan]
 
-    inferred_parameters_2 = calibrate(
-        model_url,
-        data,
-        data_timespan,
-        start_time=start_time,
-        noise_model="normal",
-        noise_model_kwargs={"scale": 1.0},
-        num_iterations=2,
-        deterministic_learnable_parameters=parameter_names,
-    )
-
-    assert isinstance(inferred_parameters_1, pyro.nn.PyroModule)
-    assert isinstance(inferred_parameters_2, pyro.nn.PyroModule)
+    calibrate_kwargs = {"start_time": start_time, **CALIBRATE_KWARGS}
 
     with pyro.poutine.seed(rng_seed=0):
-        calibrated_result_1 = sample(
-            model_url,
-            end_time,
-            logging_step_size,
-            1,
-            start_time=start_time,
-            inferred_parameters=inferred_parameters_1,
-        )["unprocessed_result"]
+        inferred_parameters, _ = calibrate(*calibrate_args, **calibrate_kwargs)
+
+    assert isinstance(inferred_parameters, pyro.nn.PyroModule)
 
     with pyro.poutine.seed(rng_seed=0):
-        calibrated_result_2 = sample(
-            model_url,
-            end_time,
-            logging_step_size,
-            1,
-            start_time=start_time,
-            inferred_parameters=inferred_parameters_2,
-        )["unprocessed_result"]
+        param_sample_1 = inferred_parameters()
 
     with pyro.poutine.seed(rng_seed=1):
-        calibrated_result_3 = sample(
-            model_url,
-            end_time,
-            logging_step_size,
-            1,
-            start_time=start_time,
-            inferred_parameters=inferred_parameters_2,
-        )["unprocessed_result"]
+        param_sample_2 = inferred_parameters()
 
-    check_states_match_in_all_but_values(calibrated_result_1, result)
-    check_states_match_in_all_but_values(calibrated_result_2, result)
-    check_states_match(calibrated_result_2, calibrated_result_3)
+    for param_name, param_value in param_sample_1.items():
+        assert not torch.allclose(param_value, param_sample_2[param_name])
+
+    result = sample(
+        *sample_args, **sample_kwargs, inferred_parameters=inferred_parameters
+    )["unprocessed_result"]
+
+    check_result_sizes(result, start_time, end_time, logging_step_size, 1)
+
+
+@pytest.mark.parametrize("model_url", MODEL_URLS)
+@pytest.mark.parametrize("start_time", START_TIMES)
+@pytest.mark.parametrize("end_time", END_TIMES)
+@pytest.mark.parametrize("logging_step_size", LOGGING_STEP_SIZES)
+def test_calibrate_deterministic(model_url, start_time, end_time, logging_step_size):
+    (
+        data,
+        data_timespan,
+        deterministic_learnable_parameters,
+        sample_args,
+        sample_kwargs,
+    ) = setup_calibrate(model_url, start_time, end_time, logging_step_size)
+    calibrate_args = [model_url, data, data_timespan]
+
+    calibrate_kwargs = {
+        "start_time": start_time,
+        "deterministic_learnable_parameters": deterministic_learnable_parameters
+        ** CALIBRATE_KWARGS,
+    }
+
+    with pyro.poutine.seed(rng_seed=0):
+        inferred_parameters, _ = calibrate(*calibrate_args, **calibrate_kwargs)
+
+    assert isinstance(inferred_parameters, pyro.nn.PyroModule)
+
+    with pyro.poutine.seed(rng_seed=0):
+        param_sample_1 = inferred_parameters()
+
+    with pyro.poutine.seed(rng_seed=1):
+        param_sample_2 = inferred_parameters()
+
+    for param_name, param_value in param_sample_1.items():
+        assert torch.allclose(param_value, param_sample_2[param_name])
+
+    result = sample(
+        *sample_args, **sample_kwargs, inferred_parameters=inferred_parameters
+    )["unprocessed_result"]
+
+    check_result_sizes(result, start_time, end_time, logging_step_size, 1)
+
+
+@pytest.mark.parametrize("model_fixture", MODELS)
+@pytest.mark.parametrize("start_time", START_TIMES)
+@pytest.mark.parametrize("end_time", END_TIMES)
+@pytest.mark.parametrize("logging_step_size", LOGGING_STEP_SIZES)
+@pytest.mark.parametrize("intervention_type", INTERVENTION_TYPES)
+@pytest.mark.parametrize("intervention_target", INTERVENTION_TARGETS)
+def test_calibrate_interventions(
+    model_fixture,
+    start_time,
+    end_time,
+    logging_step_size,
+    intervention_type,
+    intervention_target,
+):
+    model_url = model_fixture.url
+
+    (
+        data,
+        data_timespan,
+        deterministic_learnable_parameters,
+        sample_args,
+        sample_kwargs,
+    ) = setup_calibrate(model_url, start_time, end_time, logging_step_size)
+    calibrate_args = [model_url, data, data_timespan]
+
+    calibrate_kwargs = {
+        "start_time": start_time,
+        "deterministic_learnable_parameters": deterministic_learnable_parameters,
+        **CALIBRATE_KWARGS,
+    }
+
+    with pyro.poutine.seed(rng_seed=0):
+        _, loss = calibrate(*calibrate_args, **calibrate_kwargs)
+
+    # SETUP INTERVENTION
+
+    model = CompiledDynamics.load(model_url)
+
+    intervention_time = (end_time + start_time) / 2  # Half way through
+
+    if intervention_target == "state":
+        initial_state = model.initial_state()
+        intervention = {k: v.detach() + 1 for k, v in initial_state.items()}
+    elif intervention_target == "parameter":
+        important_parameter_name = model_fixture.important_parameter
+        important_parameter = getattr(model, important_parameter_name)
+        intervention = {important_parameter_name: important_parameter.detach() + 1}
+
+    if intervention_type == "static":
+        time_key = intervention_time
+    elif intervention_type == "dynamic":
+        # Same intervention time expressed as an event function
+        def time_key(time, _):
+            return time - intervention_time
+
+    calibrate_kwargs[f"{intervention_type}_{intervention_target}_interventions"] = {
+        time_key: intervention
+    }
+
+    with pyro.poutine.seed(rng_seed=0):
+        intervened_parameters, intervened_loss = calibrate(
+            *calibrate_args, **calibrate_kwargs
+        )
+
+    assert intervened_loss != loss
+
+    result = sample(
+        *sample_args, **sample_kwargs, inferred_parameters=intervened_parameters
+    )["unprocessed_result"]
+
+    check_result_sizes(result, start_time, end_time, logging_step_size, 1)
 
 
 @pytest.mark.parametrize("sample_method", SAMPLE_METHODS)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -242,8 +242,8 @@ def test_calibrate_deterministic(model_url, start_time, end_time, logging_step_s
 
     calibrate_kwargs = {
         "start_time": start_time,
-        "deterministic_learnable_parameters": deterministic_learnable_parameters
-        ** CALIBRATE_KWARGS,
+        "deterministic_learnable_parameters": deterministic_learnable_parameters,
+        **CALIBRATE_KWARGS,
     }
 
     with pyro.poutine.seed(rng_seed=0):


### PR DESCRIPTION
This PR adds parameter intervention to the `calibrate` interface, and refactors the interface tests to be more modular.

Here, adding an intervention to `calibrate` refers to the scenario where we are conditioning on data that was drawn from an interventional distribution. In other words, this is the continuous-time analog of how experimental data is incorporated into probabilistic inferences in this paper: https://arxiv.org/abs/1910.14124