### PR TITLE
Add back pyciemss logging wrapper to calibrate

### DIFF
--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -299,6 +299,7 @@ def sample(
     return prepare_interchange_dictionary(samples)
 
 
+@pyciemss_logging_wrapper
 def calibrate(
     model_path_or_json: Union[str, Dict],
     data_path: str,


### PR DESCRIPTION
As discussed in #440 , it appears that the `pyciemss_logging_wrapper` decorator was previously omitted from the `calibrate` interface method. This tiny PR adds it back in.