### PR TITLE
Add progress hook (and example usage in test) for `calibrate`

### DIFF
--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -324,6 +324,7 @@ def calibrate(
     verbose: bool = False,
     num_particles: int = 1,
     deterministic_learnable_parameters: List[str] = [],
+    progress_hook: Callable = lambda i, loss: None,
 ) -> Tuple[pyro.nn.PyroModule, float]:
     """
     Infer parameters for a DynamicalSystem model conditional on data.
@@ -398,6 +399,11 @@ def calibrate(
         - deterministic_learnable_parameters: List[str]
             - A list of parameter names that should be learned deterministically.
             - By default, all parameters are learned probabilistically.
+        - progress_hook: Callable[[int, float], None]
+            - A function that takes in the current iteration and the current loss.
+            - This is called at the beginning of each iteration.
+            - By default, this is a no-op.
+            - This can be used to implement custom progress bars.
 
     Returns:
         - inferred_parameters: pyro.nn.PyroModule
@@ -492,6 +498,8 @@ def calibrate(
     pyro.clear_param_store()
 
     for i in range(num_iterations):
+        # Call a progress hook at the beginning of each iteration. This is used to implement custom progress bars.
+        progress_hook(i, loss)
         loss = svi.step()
         if verbose:
             if i % 25 == 0:

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -347,6 +347,47 @@ def test_calibrate_interventions(
     check_result_sizes(result, start_time, end_time, logging_step_size, 1)
 
 
+@pytest.mark.parametrize("model_fixture", MODELS)
+@pytest.mark.parametrize("start_time", START_TIMES)
+@pytest.mark.parametrize("end_time", END_TIMES)
+@pytest.mark.parametrize("logging_step_size", LOGGING_STEP_SIZES)
+def test_calibrate_progress_hook(model_fixture, start_time, end_time, logging_step_size):
+    model_url = model_fixture.url
+
+    (
+        _,
+        calibrate_end_time,
+        sample_args,
+        sample_kwargs,
+    ) = setup_calibrate(model_fixture, start_time, end_time, logging_step_size)
+
+    calibrate_args = [model_url, model_fixture.data_path]
+
+    class TestProgressHook:
+        def __init__(self):
+            self.iterations = []
+            self.losses = []
+
+        def __call__(self, iteration, loss):
+            # Log the loss and iteration number
+            self.iterations.append(iteration)
+            self.losses.append(loss)
+
+    progress_hook = TestProgressHook()
+
+    calibrate_kwargs = {
+        "data_mapping": model_fixture.data_mapping,
+        "start_time": start_time,
+        "progress_hook": progress_hook,
+        **CALIBRATE_KWARGS,
+    }
+
+    calibrate(*calibrate_args, **calibrate_kwargs)
+
+    assert len(progress_hook.iterations) == CALIBRATE_KWARGS["num_iterations"]
+    assert len(progress_hook.losses) == CALIBRATE_KWARGS["num_iterations"]
+
+
 @pytest.mark.parametrize("sample_method", SAMPLE_METHODS)
 @pytest.mark.parametrize("url", MODEL_URLS)
 @pytest.mark.parametrize("start_time", START_TIMES)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -351,7 +351,9 @@ def test_calibrate_interventions(
 @pytest.mark.parametrize("start_time", START_TIMES)
 @pytest.mark.parametrize("end_time", END_TIMES)
 @pytest.mark.parametrize("logging_step_size", LOGGING_STEP_SIZES)
-def test_calibrate_progress_hook(model_fixture, start_time, end_time, logging_step_size):
+def test_calibrate_progress_hook(
+    model_fixture, start_time, end_time, logging_step_size
+):
     model_url = model_fixture.url
 
     (


### PR DESCRIPTION
This small PR addresses a comment in #444 by @fivegrant about how the progress hook for `calibrate` went missing after the refactoring PR in #431 . Here, we implement a progress hook by calling a user-provided function of the iteration id `i` and the `loss`, which the user can make stateful. In the tests we show an example of a progress hook that logs the iteration ids and losses, and stores them as an attribute.