### PR TITLE
Add parallel sampling when there are no interventions

### DIFF
--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -138,7 +138,7 @@ def ensemble_sample(
         )
 
     samples = pyro.infer.Predictive(
-        wrapped_model, guide=inferred_parameters, num_samples=num_samples
+        wrapped_model, guide=inferred_parameters, num_samples=num_samples, parallel=True
     )()
 
     return prepare_interchange_dictionary(samples)
@@ -292,8 +292,10 @@ def sample(
             # Adding noise to the model so that we can access the noisy trajectory in the Predictive object.
             compiled_noise_model(full_trajectory)
 
+    parallel = False if len(intervention_handlers) > 0 else True
+
     samples = pyro.infer.Predictive(
-        wrapped_model, guide=inferred_parameters, num_samples=num_samples
+        wrapped_model, guide=inferred_parameters, num_samples=num_samples, parallel=parallel
     )()
 
     return prepare_interchange_dictionary(samples)

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -295,7 +295,10 @@ def sample(
     parallel = False if len(intervention_handlers) > 0 else True
 
     samples = pyro.infer.Predictive(
-        wrapped_model, guide=inferred_parameters, num_samples=num_samples, parallel=parallel
+        wrapped_model,
+        guide=inferred_parameters,
+        num_samples=num_samples,
+        parallel=parallel,
     )()
 
     return prepare_interchange_dictionary(samples)

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -126,7 +126,7 @@ def _eval_deriv_mira(
     dX: State[torch.Tensor] = dict()
     for i, var in enumerate(src.variables.values()):
         k = get_name(var)
-        dX[k] = numeric_deriv[i]
+        dX[k] = numeric_deriv[..., i]
     return dX
 
 
@@ -146,7 +146,7 @@ def _eval_initial_state_mira(
     X: State[torch.Tensor] = dict()
     for i, var in enumerate(src.variables.values()):
         k = get_name(var)
-        X[k] = numeric_initial_state[i]
+        X[k] = numeric_initial_state[..., i]
     return X
 
 


### PR DESCRIPTION
This small PR changes the behavior of `pyro.infer.Predictive` to batch multiple samples into a single vectorized ode solve. ChiRho does not currently support parallel sampling with dynamic interruptions. ChiRho does support parallel sampling with static interruptions, but I am running into some difficulty getting those to work with the compiled dynamics module. While this PR does not fully catch up to ChiRho's functionality (i.e. it misses parallel sampling with only static interventions), it still represents a substantial improvement.

Will address the missing functionality in a follow-up PR.