### PR TITLE
adding check for num_iterations in calibrate

### DIFF
--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -426,6 +426,9 @@ def calibrate(
     model = CompiledDynamics.load(model_path_or_json)
 
     data_timepoints, data = load_data(data_path, data_mapping=data_mapping)
+    
+    # Check that num_iterations is a positive integer
+    assert isinstance(num_iterations, int) and num_iterations > 0, "num_iterations must be a positive integer."
 
     def autoguide(model):
         guide = pyro.infer.autoguide.AutoGuideList(model)

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -426,9 +426,11 @@ def calibrate(
     model = CompiledDynamics.load(model_path_or_json)
 
     data_timepoints, data = load_data(data_path, data_mapping=data_mapping)
-    
+
     # Check that num_iterations is a positive integer
-    assert isinstance(num_iterations, int) and num_iterations > 0, "num_iterations must be a positive integer."
+    assert (
+        isinstance(num_iterations, int) and num_iterations > 0
+    ), "num_iterations must be a positive integer."
 
     def autoguide(model):
         guide = pyro.infer.autoguide.AutoGuideList(model)

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -428,9 +428,8 @@ def calibrate(
     data_timepoints, data = load_data(data_path, data_mapping=data_mapping)
 
     # Check that num_iterations is a positive integer
-    assert (
-        isinstance(num_iterations, int) and num_iterations > 0
-    ), "num_iterations must be a positive integer."
+    if not (isinstance(num_iterations, int) and num_iterations > 0):
+        raise ValueError("num_iterations must be a positive integer")
 
     def autoguide(model):
         guide = pyro.infer.autoguide.AutoGuideList(model)

--- a/tests/test_calibrate_error_messages.py
+++ b/tests/test_calibrate_error_messages.py
@@ -1,0 +1,70 @@
+import unittest
+
+import torch
+
+from pyciemss.interfaces import calibrate
+
+
+# Unit test to assert that incorrect input to calibrate is caught
+class TestCalibrateErrorMessages(unittest.TestCase):
+    model_path = "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/"
+    data_path = "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/datasets/"
+    model_location = model_path + "SEIRHD_NPI_Type1_petrinet.json"
+    data_location = data_path + "traditional.csv"
+    data_mapping = {"Infected": "I"}
+
+    def test_positive_int(self):
+        # Assert that providing a positive int does not raise an error
+        try:
+            calibrate(
+                self.model_location,
+                self.data_location,
+                data_mapping=self.data_mapping,
+                num_iterations=3,
+            )
+        except ValueError:
+            self.fail("Providing a positive integer erroneously raised a ValueError")
+
+    def test_float(self):
+        # Assert that providing a float raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                self.model_location,
+                self.data_location,
+                data_mapping=self.data_mapping,
+                num_iterations=3.5,
+            )
+
+    def test_negative_int(self):
+        # Assert that providing a negative integer raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                self.model_location,
+                self.data_location,
+                data_mapping=self.data_mapping,
+                num_iterations=-3,
+            )
+
+    def test_zero(self):
+        # Assert that providing 0 raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                self.model_location,
+                self.data_location,
+                data_mapping=self.data_mapping,
+                num_iterations=0,
+            )
+
+    def test_tensor_int(self):
+        # Assert that providing a tensor with an int raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                self.model_location,
+                self.data_location,
+                data_mapping=self.data_mapping,
+                num_iterations=torch.tensor(5),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,3 +1,5 @@
+import unittest
+
 import numpy as np
 import pandas as pd
 import pyro
@@ -420,3 +422,63 @@ def test_output_format(
 
     assert processed_result["timepoint_id"].dtype == np.int64
     assert processed_result["sample_id"].dtype == np.int64
+
+
+# Unit test to assert that incorrect input to calibrate is caught
+@pytest.mark.parametrize("model_fixture", MODELS)
+class TestCalibrateErrorMessages(UnitTest.TestCase):
+    def test_positive_int(self):
+        # Assert that providing a positive int does not raise an error
+        try:
+            calibrate(
+                model_fixture.url,
+                model_fixture.data_path,
+                data_mapping=model_fixture.data_mapping,
+                num_iterations=3,
+            )
+        except ValueError:
+            self.fail("Providing a positive integer erroneously raised a ValueError")
+
+    def test_float(self):
+        # Assert that providing a float raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                model_fixture.url,
+                model_fixture.data_path,
+                data_mapping=model_fixture.data_mapping,
+                num_iterations=3.5,
+            )
+
+    def test_negative_int(self):
+        # Assert that providing a negative integer raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                model_fixture.url,
+                model_fixture.data_path,
+                data_mapping=model_fixture.data_mapping,
+                num_iterations=-3,
+            )
+
+    def test_zero(self):
+        # Assert that providing 0 raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                model_fixture.url,
+                model_fixture.data_path,
+                data_mapping=model_fixture.data_mapping,
+                num_iterations=0,
+            )
+
+    def test_tensor_int(self):
+        # Assert that providing a tensor with an int raises a ValueError
+        with self.assertRaises(ValueError):
+            calibrate(
+                model_fixture.url,
+                model_fixture.data_path,
+                data_mapping=model_fixture.data_mapping,
+                num_iterations=torch.tensor(5),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import pandas as pd
 import pyro
@@ -422,63 +420,3 @@ def test_output_format(
 
     assert processed_result["timepoint_id"].dtype == np.int64
     assert processed_result["sample_id"].dtype == np.int64
-
-
-# Unit test to assert that incorrect input to calibrate is caught
-@pytest.mark.parametrize("model_fixture", MODELS)
-class TestCalibrateErrorMessages(UnitTest.TestCase):
-    def test_positive_int(self):
-        # Assert that providing a positive int does not raise an error
-        try:
-            calibrate(
-                model_fixture.url,
-                model_fixture.data_path,
-                data_mapping=model_fixture.data_mapping,
-                num_iterations=3,
-            )
-        except ValueError:
-            self.fail("Providing a positive integer erroneously raised a ValueError")
-
-    def test_float(self):
-        # Assert that providing a float raises a ValueError
-        with self.assertRaises(ValueError):
-            calibrate(
-                model_fixture.url,
-                model_fixture.data_path,
-                data_mapping=model_fixture.data_mapping,
-                num_iterations=3.5,
-            )
-
-    def test_negative_int(self):
-        # Assert that providing a negative integer raises a ValueError
-        with self.assertRaises(ValueError):
-            calibrate(
-                model_fixture.url,
-                model_fixture.data_path,
-                data_mapping=model_fixture.data_mapping,
-                num_iterations=-3,
-            )
-
-    def test_zero(self):
-        # Assert that providing 0 raises a ValueError
-        with self.assertRaises(ValueError):
-            calibrate(
-                model_fixture.url,
-                model_fixture.data_path,
-                data_mapping=model_fixture.data_mapping,
-                num_iterations=0,
-            )
-
-    def test_tensor_int(self):
-        # Assert that providing a tensor with an int raises a ValueError
-        with self.assertRaises(ValueError):
-            calibrate(
-                model_fixture.url,
-                model_fixture.data_path,
-                data_mapping=model_fixture.data_mapping,
-                num_iterations=torch.tensor(5),
-            )
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This PR adds an assert statement (see code below) in `calibrate` that will give the error message: "num_iterations must be a positive integer." if `num_iterations` is not a positive integer.

```python
# Check that num_iterations is a positive integer
assert isinstance(num_iterations, int) and num_iterations > 0, "num_iterations must be a positive integer."
```

Closes #456 