### PR TITLE
Revert to old way of doing package discovery

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.8
 
-packages = 
-    pyciemss
-    pyciemss.integration_utils
-    pyciemss.mira_integration
-    pyciemss.ensemble
+packages = find:
 
 [options.package_data]
 * = *.json


### PR DESCRIPTION
@SamWitty this changes `setup.cfg` back to the way it was before I messed with it during the hackathon.