### PR TITLE
Added typing fixes after `pyro==1.9.0` bump

### DIFF
--- a/pyciemss/ensemble/compiled_dynamics.py
+++ b/pyciemss/ensemble/compiled_dynamics.py
@@ -33,7 +33,7 @@ class EnsembleCompiledDynamics(pyro.nn.PyroModule):
         is_traced: bool = False,
     ) -> State[torch.Tensor]:
         model_weights = pyro.sample(
-            "model_weights", pyro.distributions.Dirichlet(self.dirichlet_alpha)
+            "model_weights", pyro.distributions.Dirichlet(self.dirichlet_alpha)  # type: ignore[attr-defined]
         )
 
         mapped_states: List[State[torch.Tensor]] = [dict()] * len(self.dynamics_models)

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -504,7 +504,7 @@ def calibrate(
 
     inferred_parameters = autoguide(wrapped_model)
 
-    optim = pyro.optim.Adam({"lr": lr})
+    optim = pyro.optim.Adam({"lr": lr})  # type: ignore[attr-defined]
     loss = pyro.infer.Trace_ELBO(num_particles=num_particles)
     svi = pyro.infer.SVI(wrapped_model, inferred_parameters, optim, loss=loss)
 

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -14,6 +14,7 @@ import sympy
 import sympytorch
 import torch
 from chirho.dynamical.ops import State
+from torch.distributions import constraints
 
 from pyciemss.compiled_dynamics import (
     _compile_deriv,
@@ -84,7 +85,7 @@ def _compile_observables_mira(
 def _compile_param_values_mira(
     src: mira.modeling.Model,
 ) -> Dict[str, Union[torch.Tensor, pyro.nn.PyroParam, pyro.nn.PyroSample]]:
-    values = {}
+    values: Dict[str, Union[torch.Tensor, pyro.nn.PyroParam, pyro.nn.PyroSample]] = {}
     for param_info in src.parameters.values():
         param_name = get_name(param_info)
 
@@ -98,7 +99,7 @@ def _compile_param_values_mira(
             param_value = mira_distribution_to_pyro(param_dist)
 
         if isinstance(param_value, torch.nn.Parameter):
-            values[param_name] = pyro.nn.PyroParam(param_value)
+            values[param_name] = pyro.nn.PyroParam(param_value, constraints.real, None)
         elif isinstance(param_value, pyro.distributions.Distribution):
             values[param_name] = pyro.nn.PyroSample(param_value)
         elif isinstance(param_value, (numbers.Number, numpy.ndarray, torch.Tensor)):

--- a/pyciemss/mira_integration/distributions.py
+++ b/pyciemss/mira_integration/distributions.py
@@ -1,20 +1,19 @@
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 import mira.metamodel
 import pyro
 
+if TYPE_CHECKING:
+    from pyro.distributions.torch_distribution import TorchDistributionMixin
 
-def mira_uniform_to_pyro(
-    parameters: Dict[str, float]
-) -> pyro.distributions.Distribution:
+
+def mira_uniform_to_pyro(parameters: Dict[str, float]) -> TorchDistributionMixin:
     minimum = parameters["minimum"]
     maximum = parameters["maximum"]
-    return pyro.distributions.Uniform(minimum, maximum)
+    return pyro.distributions.Uniform(minimum, maximum)  # type: ignore[attr-defined]
 
 
-def mira_normal_to_pyro(
-    parameters: Dict[str, float]
-) -> pyro.distributions.Distribution:
+def mira_normal_to_pyro(parameters: Dict[str, float]) -> TorchDistributionMixin:
     if "mean" in parameters.keys():
         mean = parameters["mean"]
 
@@ -27,7 +26,7 @@ def mira_normal_to_pyro(
 
     #  Pyro distributions are thing wrappers around torch distributions.
     #  See https://pytorch.org/docs/stable/generated/torch.normal.html
-    return pyro.distributions.Normal(mean, std)
+    return pyro.distributions.Normal(mean, std)  # type: ignore[attr-defined]
 
 
 # TODO: Add lognormal, beta, gamma, etc.
@@ -47,7 +46,7 @@ _MIRA_TO_PYRO = {
 
 def mira_distribution_to_pyro(
     mira_dist: mira.metamodel.template_model.Distribution,
-) -> pyro.distributions.Distribution:
+) -> TorchDistributionMixin:
     if mira_dist.type not in _MIRA_TO_PYRO.keys():
         raise NotImplementedError(
             f"Conversion from MIRA distribution type {mira_dist.type} to Pyro distribution not implemented."

--- a/pyciemss/mira_integration/distributions.py
+++ b/pyciemss/mira_integration/distributions.py
@@ -1,10 +1,8 @@
-from typing import TYPE_CHECKING, Dict
+from typing import Dict
 
 import mira.metamodel
 import pyro
-
-if TYPE_CHECKING:
-    from pyro.distributions.torch_distribution import TorchDistributionMixin
+from pyro.distributions.torch_distribution import TorchDistributionMixin
 
 
 def mira_uniform_to_pyro(parameters: Dict[str, float]) -> TorchDistributionMixin:

--- a/pyciemss/observation.py
+++ b/pyciemss/observation.py
@@ -1,7 +1,10 @@
-from typing import Dict, Set
+from typing import TYPE_CHECKING, Dict, Set
 
 import pyro
 import torch
+
+if TYPE_CHECKING:
+    from pyro.distributions.torch_distribution import TorchDistributionMixin
 
 
 class NoiseModel(pyro.nn.PyroModule):
@@ -21,9 +24,7 @@ class StateIndependentNoiseModel(NoiseModel):
     def __init__(self, vars: Set[str] = set()):
         super().__init__(vars=vars)
 
-    def markov_kernel(
-        self, name: str, val: torch.Tensor
-    ) -> pyro.distributions.Distribution:
+    def markov_kernel(self, name: str, val: torch.Tensor) -> TorchDistributionMixin:
         raise NotImplementedError
 
     def forward(self, state: Dict[str, torch.Tensor]) -> None:
@@ -39,7 +40,5 @@ class NormalNoiseModel(StateIndependentNoiseModel):
         super().__init__(vars=vars)
         self.scale = scale
 
-    def markov_kernel(
-        self, name: str, val: torch.Tensor
-    ) -> pyro.distributions.Distribution:
-        return pyro.distributions.Normal(val, self.scale * torch.abs(val)).to_event(1)
+    def markov_kernel(self, name: str, val: torch.Tensor) -> TorchDistributionMixin:
+        return pyro.distributions.Normal(val, self.scale * torch.abs(val)).to_event(1)  # type: ignore[attr-defined]

--- a/pyciemss/visuals/barycenter.py
+++ b/pyciemss/visuals/barycenter.py
@@ -4,7 +4,7 @@ import matplotlib.tri as tri
 import numpy as np
 import pandas as pd
 import torch
-from pyro.distributions import Dirichlet
+from pyro.distributions import Dirichlet  # type: ignore[attr-defined]
 
 from . import vega
 


### PR DESCRIPTION
This small PR addresses a number of linting errors that were introduced as a result of more refined types from the pyro 1.9.0 release https://github.com/pyro-ppl/pyro/releases/tag/1.9.0.

Currently blocked by some upstream changes that need to be made in ChiRho.