### PR TITLE
Pin `pyro==1.8.6` to resolve upstream bugs in ChiRho

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ install_requires =
     torch >= 1.8.0
     mira @ git+https://github.com/indralab/mira.git@0.3.0
     chirho[dynamical] == 0.2.0
+    pyro-ppl == 1.8.6
     sympytorch
     torchdiffeq
     pandas


### PR DESCRIPTION
This tiny PR pins pyro to 1.8.6. See https://github.com/BasisResearch/chirho/pull/523 and https://github.com/BasisResearch/chirho/pull/522 for additional discussion.