### PR TITLE
remove parallel sampling and add PDE to test

### DIFF
--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -138,7 +138,7 @@ def ensemble_sample(
             wrapped_model,
             guide=inferred_parameters,
             num_samples=num_samples,
-            parallel=True,
+            # parallel=True,
         )()
 
         return prepare_interchange_dictionary(samples)
@@ -293,13 +293,13 @@ def sample(
                 # Adding noise to the model so that we can access the noisy trajectory in the Predictive object.
                 compiled_noise_model(full_trajectory)
 
-        parallel = False if len(intervention_handlers) > 0 else True
+        # parallel = False if len(intervention_handlers) > 0 else True
 
         samples = pyro.infer.Predictive(
             wrapped_model,
             guide=inferred_parameters,
             num_samples=num_samples,
-            parallel=parallel,
+            # parallel=parallel,
         )()
 
         return prepare_interchange_dictionary(samples)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,6 +10,7 @@ from pyciemss.ouu.qoi import obs_nday_average_qoi
 T = TypeVar("T")
 
 MODELS_PATH = "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/"
+PDE_PATH = "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/pde-petri-amrs/petrinet/"
 DATA_PATH = "https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/datasets/"
 
 
@@ -54,6 +55,12 @@ PETRI_MODELS = [
         os.path.join(DATA_PATH, "SIR_data_case_hosp.csv"),
         {"case": "infected", "hosp": "hospitalized"},
         True,
+    ),
+    ModelFixture(
+        os.path.join(
+            PDE_PATH, "examples/pde/advection/advection_backward_1_0.01_3.json"
+        ),
+        "u",
     ),
 ]
 


### PR DESCRIPTION
This small PR adds a workaround for some tensor shape errors (see https://github.com/ciemss/pyciemss/issues/487, https://github.com/ciemss/pyciemss/issues/480, and https://github.com/ciemss/pyciemss/issues/468) which results from TorchDiffEq only broadcasting along a single batch dimension. We address this problem in ChiRho by collapsing all batch dimensions to a single batch dimension before running the solver, but this has strange interactions with handlers that modify tensor shapes when encountering a sample statement. To address this in the short term, this PR removes `parallel=True` arguments from the predictive handlers, which parallelize by making full use of tensor broadcasting. In the future, when we update to a fully broadcastable solver, this can be reverted.