### PR TITLE
Restoring time-unit pass-through from interfaces.

### DIFF
--- a/pyciemss/integration_utils/result_processing.py
+++ b/pyciemss/integration_utils/result_processing.py
@@ -38,7 +38,7 @@ def convert_to_output_format(
     """
 
     if time_unit is not None and timepoints is None:
-        raise ValueError("`timeponts` must be supplied when a `time_unit` is supplied")
+        raise ValueError("`timepionts` must be supplied when a `time_unit` is supplied")
 
     pyciemss_results: Dict[str, Dict[str, torch.Tensor]] = {
         "parameters": {},
@@ -70,6 +70,11 @@ def convert_to_output_format(
         "sample_id": np.repeat(np.array(range(num_samples)), num_timepoints),
     }
 
+    if timepoints is not None:
+        timepoints = [*timepoints]
+        label = "timepoint_unknown" if time_unit is None else f"timepoint_{time_unit}"
+        output[label] = [float(timepoints[v]) for v in output["timepoint_id"]]
+
     # Parameters
     output = {
         **output,
@@ -89,9 +94,5 @@ def convert_to_output_format(
     }
 
     result = pd.DataFrame(output)
-    if time_unit is not None and timepoints is not None:
-        timepoints = [*timepoints]
-        all_timepoints = result["timepoint_id"].map(lambda v: timepoints[v])
-        result = result.assign(**{f"timepoint_{time_unit}": all_timepoints})
 
     return result

--- a/pyciemss/integration_utils/result_processing.py
+++ b/pyciemss/integration_utils/result_processing.py
@@ -38,7 +38,7 @@ def convert_to_output_format(
     """
 
     if time_unit is not None and timepoints is None:
-        raise ValueError("`timepionts` must be supplied when a `time_unit` is supplied")
+        raise ValueError("`timepoints` must be supplied when a `time_unit` is supplied")
 
     pyciemss_results: Dict[str, Dict[str, torch.Tensor]] = {
         "parameters": {},
@@ -73,7 +73,7 @@ def convert_to_output_format(
     if timepoints is not None:
         timepoints = [*timepoints]
         label = "timepoint_unknown" if time_unit is None else f"timepoint_{time_unit}"
-        output[label] = [float(timepoints[v]) for v in output["timepoint_id"]]
+        output[label] = np.array(float(timepoints[v]) for v in output["timepoint_id"])
 
     # Parameters
     output = {

--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -45,6 +45,7 @@ def ensemble_sample(
     solver_options: Dict[str, Any] = {},
     start_time: float = 0.0,
     inferred_parameters: Optional[pyro.nn.PyroModule] = None,
+    time_unit: Optional[str] = None,
 ):
     """
     Load a collection of models from files, compile them into an ensemble probabilistic program,
@@ -140,7 +141,9 @@ def ensemble_sample(
             num_samples=num_samples,
         )()
 
-        return prepare_interchange_dictionary(samples)
+        return prepare_interchange_dictionary(
+            samples, timepoints=logging_times, time_unit=time_unit
+        )
 
 
 @pyciemss_logging_wrapper
@@ -155,6 +158,7 @@ def sample(
     solver_method: str = "dopri5",
     solver_options: Dict[str, Any] = {},
     start_time: float = 0.0,
+    time_unit: Optional[str] = None,
     inferred_parameters: Optional[pyro.nn.PyroModule] = None,
     static_state_interventions: Dict[torch.Tensor, Dict[str, Intervention]] = {},
     static_parameter_interventions: Dict[torch.Tensor, Dict[str, Intervention]] = {},
@@ -298,7 +302,9 @@ def sample(
             num_samples=num_samples,
         )()
 
-        return prepare_interchange_dictionary(samples)
+        return prepare_interchange_dictionary(
+            samples, timepoints=logging_times, time_unit=time_unit
+        )
 
 
 @pyciemss_logging_wrapper

--- a/pyciemss/visuals/trajectories.py
+++ b/pyciemss/visuals/trajectories.py
@@ -41,6 +41,7 @@ def select_traces(
         relabel (None, Dict[str, str]): Relabel elements for rendering.  Happens
             after keep & drop.
 
+        #TODO: Add a way to control the time-axis.  _nice_df does some heuristics BUT we should provide an override
     """
     traces_df = _nice_df(traces)
     traces_df = _keep_drop_rename(traces_df, keep, drop, relabel)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -422,15 +422,24 @@ def test_output_format(
     sample_method, url, start_time, end_time, logging_step_size, num_samples
 ):
     processed_result = sample_method(
-        url, end_time, logging_step_size, num_samples, start_time=start_time
+        url,
+        end_time,
+        logging_step_size,
+        num_samples,
+        start_time=start_time,
+        time_unit="nominal",
     )["data"]
     assert isinstance(processed_result, pd.DataFrame)
     assert processed_result.shape[0] == num_samples * len(
         torch.arange(start_time + logging_step_size, end_time, logging_step_size)
     )
     assert processed_result.shape[1] >= 2
-    assert list(processed_result.columns)[:2] == ["timepoint_id", "sample_id"]
-    for col_name in processed_result.columns[2:]:
+    assert list(processed_result.columns)[:3] == [
+        "timepoint_id",
+        "sample_id",
+        "timepoint_nominal",
+    ]
+    for col_name in processed_result.columns[3:]:
         assert col_name.split("_")[-1] in ("param", "state")
         assert processed_result[col_name].dtype == np.float64
 


### PR DESCRIPTION
In response to #500, restores the use of `time_unit` in creating the results dataframe from the integration interfaces.

Manually verified that the trajectories plot uses this for labeling, but did not test in an automated way.