### PR TITLE
Fix calibrate to work on observables as well as state

### DIFF
--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -311,7 +311,10 @@ def sample(
 
             if noise_model is not None:
                 compiled_noise_model = compile_noise_model(
-                    noise_model, vars=set(full_trajectory.keys()), **noise_model_kwargs
+                    noise_model,
+                    vars=set(full_trajectory.keys()),
+                    observables=model.observables,
+                    **noise_model_kwargs,
                 )
                 # Adding noise to the model so that we can access the noisy trajectory in the Predictive object.
                 compiled_noise_model(full_trajectory)
@@ -528,6 +531,7 @@ def calibrate(
     _noise_model = compile_noise_model(
         noise_model,
         vars=set(data.keys()),
+        observables=model.observables,
         **noise_model_kwargs,
     )
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -33,7 +33,7 @@ def dummy_ensemble_sample(model_path_or_json, *args, **kwargs):
 
 
 def setup_calibrate(model_fixture, start_time, end_time, logging_step_size):
-    if model_fixture.data_path is None or model_fixture.data_mapped_to_observable:
+    if model_fixture.data_path is None:
         pytest.skip("TODO: create temporary file")
 
     data_timepoints = load_data(model_fixture.data_path)[0]


### PR DESCRIPTION
This PR adds observables to the `noise_model`, which can then be used to `calibrate` or `sample`.

To confirm that this fixes #492 , see that the CI fails after [3c3b3e7](https://github.com/ciemss/pyciemss/pull/517/commits/3c3b3e75cad68238e1b94b94f30328514b8422bf), which only uncomments a skipped test. After the fix in subsequent commits, the tests in the CI again pass.

Subsumes #516  .