### PR TITLE
Throw an error in `calibrate` if no parameters have distributions

### DIFF
--- a/pyciemss/interfaces.py
+++ b/pyciemss/interfaces.py
@@ -648,6 +648,12 @@ def calibrate(
 
     model = CompiledDynamics.load(model_path_or_json)
 
+    if len(model.params_with_distributions()) == 0:
+        raise ValueError(
+            "The model does not contain distributions representing uncertainty over any parameters."
+            "As there is no uncertainty, `calibrate` will not update any parameters."
+        )
+
     data_timepoints, data = load_data(data_path, data_mapping=data_mapping)
 
     # Check that num_iterations is a positive integer

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -21,6 +21,7 @@ from .fixtures import (
     MAPPING_FOR_DATA_TESTS,
     MODEL_URLS,
     MODELS,
+    MODELS_WITHOUT_DISTRIBUTIONS,
     NON_POS_INTS,
     NUM_SAMPLES,
     OPT_MODELS,
@@ -696,4 +697,14 @@ def test_bad_euler_solver_optimize(model_fixture):
             2.0,
             logging_step_size,
             **optimize_kwargs,
+        )
+
+
+@pytest.mark.parametrize("model_fixture", MODELS_WITHOUT_DISTRIBUTIONS)
+def test_calibrate_no_distributions(model_fixture):
+    with pytest.raises(ValueError):
+        calibrate(
+            model_fixture.url,
+            model_fixture.data_path,
+            data_mapping=model_fixture.data_mapping,
         )


### PR DESCRIPTION
See title.