### PR TITLE
Add more informative error if adaptive time step underflows

### DIFF
--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -90,11 +90,10 @@ class CompiledDynamics(pyro.nn.PyroModule):
                             "This is likely due to a stiff system of ODEs. "
                             "Try changing the (distribution on) parameters, the rate laws, "
                             "the initial state, or the time span."
-                        )
+                        ) from e
                     else:
                         raise e
-                    
-                
+
                 state = lt.trajectory
         else:
             state = simulate(self.deriv, self.initial_state(), start_time, end_time)

--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -81,7 +81,20 @@ class CompiledDynamics(pyro.nn.PyroModule):
 
         if logging_times is not None:
             with LogTrajectory(logging_times) as lt:
-                simulate(self.deriv, self.initial_state(), start_time, end_time)
+                try:
+                    simulate(self.deriv, self.initial_state(), start_time, end_time)
+                except AssertionError as e:
+                    if str(e) == "AssertionError: underflow in dt nan":
+                        raise AssertionError(
+                            "Underflow in the adaptive time step size. "
+                            "This is likely due to a stiff system of ODEs. "
+                            "Try changing the (distribution on) parameters, the rate laws, "
+                            "the initial state, or the time span."
+                        )
+                    else:
+                        raise e
+                    
+                
                 state = lt.trajectory
         else:
             state = simulate(self.deriv, self.initial_state(), start_time, end_time)


### PR DESCRIPTION
This small PR adds a more informative error message than the one found buried deep with `TorchDiffEq`.