### PR TITLE
Set the minimum value for the `NormalNoiseModel` noise variance`

### DIFF
--- a/pyciemss/observation.py
+++ b/pyciemss/observation.py
@@ -4,6 +4,8 @@ import pyro
 import torch
 
 
+EPS = 1e-7
+
 class NoiseModel(pyro.nn.PyroModule):
     """
     An NoiseModel is a function that takes a state and returns a state sampled from some pyro distribution.
@@ -60,4 +62,5 @@ class NormalNoiseModel(StateIndependentNoiseModel):
     def markov_kernel(
         self, name: str, val: torch.Tensor
     ) -> pyro.distributions.Distribution:
-        return pyro.distributions.Normal(val, self.scale * torch.abs(val)).to_event(1)
+        var = torch.minimum(self.scale * torch.abs(val), EPS)
+        return pyro.distributions.Normal(val, var).to_event(1)


### PR DESCRIPTION
This tiny PR resolves an issue where state variable assignments of exactly 0 resulted in 0 noise variance, and thus would throw appropriate numerical errors. This has not been relevant thusfar, as we've only added a noise kernel to states after the initial state. However, with the changes in #570 , including logging the initial state, this will no longer be the case.