### PR TITLE
Add parameters to observables

### DIFF
--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -167,9 +167,14 @@ def _eval_observables_mira(
 
     # TODO: support event_dim > 0 upstream in ChiRho
     # Default to time being the rightmost dimension
-    parameters_expanded = {k: torch.unsqueeze(v, -1) if len(v.size()) > 0 else v for k, v in parameters.items()}
+    parameters_expanded = {
+        k: torch.unsqueeze(v, -1) if len(v.size()) > 0 else v
+        for k, v in parameters.items()
+    }
 
-    numeric_observables = param_module.numeric_observables_func(**X, **parameters_expanded)
+    numeric_observables = param_module.numeric_observables_func(
+        **X, **parameters_expanded
+    )
 
     observables: State[torch.Tensor] = dict()
     for i, obs in enumerate(src.observables.values()):

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -165,7 +165,11 @@ def _eval_observables_mira(
         if not param_info.placeholder
     }
 
-    numeric_observables = param_module.numeric_observables_func(**X, **parameters)
+    # TODO: support event_dim > 0 upstream in ChiRho
+    # Default to time being the rightmost dimension
+    parameters_expanded = {k: torch.unsqueeze(v, -1) if len(v.size()) > 0 else v for k, v in parameters.items()}
+
+    numeric_observables = param_module.numeric_observables_func(**X, **parameters_expanded)
 
     observables: State[torch.Tensor] = dict()
     for i, obs in enumerate(src.observables.values()):

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -158,8 +158,14 @@ def _eval_observables_mira(
 ) -> State[torch.Tensor]:
     if len(src.observables) == 0:
         return dict()
+    
+    parameters = {
+        get_name(param_info): getattr(param_module, get_name(param_info))
+        for param_info in src.parameters.values()
+        if not param_info.placeholder
+    }
 
-    numeric_observables = param_module.numeric_observables_func(**X)
+    numeric_observables = param_module.numeric_observables_func(**X, **parameters)
 
     observables: State[torch.Tensor] = dict()
     for i, obs in enumerate(src.observables.values()):

--- a/pyciemss/mira_integration/compiled_dynamics.py
+++ b/pyciemss/mira_integration/compiled_dynamics.py
@@ -158,7 +158,7 @@ def _eval_observables_mira(
 ) -> State[torch.Tensor]:
     if len(src.observables) == 0:
         return dict()
-    
+
     parameters = {
         get_name(param_info): getattr(param_module, get_name(param_info))
         for param_info in src.parameters.values()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -67,6 +67,13 @@ PETRI_MODELS = [
         ),
         "u",
     ),
+    ModelFixture( 
+        os.path.join(MODELS_PATH, "SIR_param_in_observables.json"),
+        "beta",
+        os.path.join(DATA_PATH, "SIR_data_case_hosp.csv"),
+        {"case": "incident_cases", "hosp": "I"}, 
+        True,
+    ),
 ]
 
 REGNET_MODELS = [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -67,11 +67,11 @@ PETRI_MODELS = [
         ),
         "u",
     ),
-    ModelFixture( 
+    ModelFixture(
         os.path.join(MODELS_PATH, "SIR_param_in_observables.json"),
         "beta",
         os.path.join(DATA_PATH, "SIR_data_case_hosp.csv"),
-        {"case": "incident_cases", "hosp": "I"}, 
+        {"case": "incident_cases", "hosp": "I"},
         True,
     ),
 ]


### PR DESCRIPTION
addresses #578 

This small PR allows for observables to be defined in terms of (potentially random) parameters. This includes a minimal change to the definition of `eval_observables` to include parameters and manage parameter tensor shapes, as well as adding a relevant test.