### PR TITLE
610 atol and rtol cannot be specified in solver options

### DIFF
--- a/pyciemss/ouu/ouu.py
+++ b/pyciemss/ouu/ouu.py
@@ -78,6 +78,8 @@ class computeRisk:
         solver_options: Dict[str, Any] = {},
         u_bounds: np.ndarray = np.atleast_2d([[0], [1]]),
         risk_bound: List[float] = [0.0],
+        rtol: float = 1e-7, 
+        atol: float = 1e-9
     ):
         self.model = model
         self.interventions = interventions
@@ -97,6 +99,8 @@ class computeRisk:
         self.u_bounds = u_bounds
         self.risk_bound = risk_bound  # used for defining penalty
         warnings.simplefilter("always", UserWarning)
+        self.rtol = rtol
+        self.atol = atol
 
     def __call__(self, x):
         if np.any(x - self.u_bounds[0, :] < 0.0) or np.any(
@@ -144,7 +148,7 @@ class computeRisk:
                 def wrapped_model():
                     with ParameterInterventionTracer():
                         with TorchDiffEq(
-                            method=self.solver_method, options=self.solver_options
+                            rtol=self.rtol, atol=self.atol, method=self.solver_method, options=self.solver_options
                         ):
                             with contextlib.ExitStack() as stack:
                                 for handler in static_parameter_intervention_handlers:


### PR DESCRIPTION
torchdiffeq uses rtol and atol as separate arguments - i.e. torchdiffeq(rtol, atol, method, solver_options). 
this PR exposes those arguments in the sampling, calibration, and optimization (ouu.py) functions in interfaces.py as well as adds tests.

- added rtol and atol arguments to sample, calibration, and optimize interfaces 
- added test cases for sample, calibration, and optimization using different rtol and atol values.  