### PR TITLE
Replaced `pandas.DataFrame.applymap` with `.map` to avoid Pandas deprecation warning

### DIFF
--- a/pyciemss/integration_utils/observation.py
+++ b/pyciemss/integration_utils/observation.py
@@ -46,7 +46,7 @@ def load_data(
             raise ValueError("Dataset cannot contain NaN or empty entries.")
 
         # Check that there is no missing data in the form of None type or char values
-        if not data_df.applymap(lambda x: isinstance(x, (int, float))).all().all():
+        if not data_df.map(lambda x: isinstance(x, (int, float))).all().all():
             raise ValueError(
                 "Dataset cannot contain None type or char values. All entries must be of type `int` or `float`."
             )


### PR DESCRIPTION
I got this warning when running `pyciemss.ensemble_calibrate`
```
[./pyciemss/pyciemss/integration_utils/observation.py:49](./pyciemss/pyciemss/integration_utils/observation.py:49): FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  if not data_df.applymap(lambda x: isinstance(x, (int, float))).all().all():
```

This PR just follows this note in the Pandas documentation:
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.applymap.html#pandas.DataFrame.applymap
```
Added in version 2.1.0: DataFrame.applymap was deprecated and renamed to DataFrame.map.
```