### PR TITLE
Modify observables computations to account for dependence on parameters that change via intervention

### DIFF
--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -249,7 +249,9 @@ class LogObservables(pyro.poutine.messenger.Messenger):
         msg["value"] = {**msg["value"], **observables}
 
     def _pyro_simulate(self, msg):
-        self.initial_observables = _squeeze_time_dim(self.model.observables(msg["args"][1]))
+        self.initial_observables = _squeeze_time_dim(
+            self.model.observables(msg["args"][1])
+        )
 
     def _pyro_post_simulate(self, msg):
         msg["args"] = (

--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -261,5 +261,7 @@ class LogObservables(pyro.poutine.messenger.Messenger):
             k: v for k, v in self.lt.trajectory.items() if k in self.observables_names
         }
         self.state = {
-            k: v for k, v in self.lt.trajectory.items() if k not in self.observables_names
+            k: v
+            for k, v in self.lt.trajectory.items()
+            if k not in self.observables_names
         }

--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -248,13 +248,13 @@ class LogObservables(pyro.poutine.messenger.Messenger):
         self.observables_names = list(observables.keys())
         msg["value"] = {**msg["value"], **observables}
 
-    def _pyro_post_simulate(self, msg):
+    def _pyro_simulate(self, msg):
+        self.initial_observables = _squeeze_time_dim(self.model.observables(msg["args"][1]))
 
-        initial_state = msg["args"][1]
-        initial_observables = _squeeze_time_dim(self.model.observables(initial_state))
+    def _pyro_post_simulate(self, msg):
         msg["args"] = (
             msg["args"][0],
-            {**initial_state, **initial_observables},
+            {**msg["args"][1], **self.initial_observables},
             msg["args"][2],
             msg["args"][3],
         )

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -826,3 +826,49 @@ def test_intervention_on_constant_param(
             torch.arange(start_time, end_time + logging_step_size, logging_step_size)
         )
         assert processed_result.shape[1] >= 2
+
+
+@pytest.mark.parametrize("sample_method", [sample])
+@pytest.mark.parametrize("model_fixture", MODELS)
+@pytest.mark.parametrize("end_time", END_TIMES)
+@pytest.mark.parametrize("logging_step_size", LOGGING_STEP_SIZES)
+@pytest.mark.parametrize("num_samples", NUM_SAMPLES)
+@pytest.mark.parametrize("start_time", START_TIMES)
+def test_observables_change_with_interventions(
+    sample_method,
+    model_fixture,
+    end_time,
+    logging_step_size,
+    num_samples,
+    start_time,
+):
+    # Assert that sample returns expected result with intervention on constant parameter
+    if "SIR_param" not in model_fixture.url:
+        pytest.skip("Only test 'SIR_param_in_obs' model")
+    else:
+        processed_result = sample_method(
+            model_fixture.url,
+            end_time,
+            logging_step_size,
+            num_samples,
+            start_time=start_time,
+            static_parameter_interventions={
+                torch.tensor(2.0): {"beta": torch.tensor(0.001)}
+            },
+        )["data"]
+
+        print(processed_result["beta_param_observable_state"][0])
+        print(
+            processed_result["beta_param_observable_state"][
+                int(end_time / logging_step_size)
+            ]
+        )
+        print(int(end_time / logging_step_size))
+
+        # The test will fail if values before and after the intervention are the same
+        assert (
+            processed_result["beta_param_observable_state"][0]
+            > processed_result["beta_param_observable_state"][
+                int(end_time / logging_step_size)
+            ]
+        )

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -857,14 +857,6 @@ def test_observables_change_with_interventions(
             },
         )["data"]
 
-        print(processed_result["beta_param_observable_state"][0])
-        print(
-            processed_result["beta_param_observable_state"][
-                int(end_time / logging_step_size)
-            ]
-        )
-        print(int(end_time / logging_step_size))
-
         # The test will fail if values before and after the intervention are the same
         assert (
             processed_result["beta_param_observable_state"][0]


### PR DESCRIPTION
Addresses #630 by computing the observables between each interruption and fusing the extended trajectories together, rather than computing observables only after the simulation has completed. This means that every time the observables are computed they use the value of the parameters as they are assigned at that particular moment in time.

This implementation makes heavy use of the existing `LogTrajectory` handler in ChiRho, which is responsible for fusing trajectories together between interruptions.