### PR TITLE
changing setup.cfg to use most recent mira

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ license_files = LICENSE
 install_requires =
     jupyter
     torch >= 1.8.0
-    mira @ git+https://github.com/indralab/mira.git@0.7.0
+    mira @ git+https://github.com/indralab/mira.git@928de3e9ef17594eb78d3d42c00d90ed0d7803a6
     chirho[dynamical] @ git+https://github.com/BasisResearch/chirho@4fbd03ce9aa25f536dc06c943ceef363cd2c56c4
     sympytorch
     torchdiffeq
@@ -24,7 +24,7 @@ install_requires =
 
 zip_safe = false
 include_package_data = true
-python_requires = >=3.8
+python_requires = >=3.9
 
 packages = find:
 


### PR DESCRIPTION
Updating `setup.cfg` to use the most recent mira version

**Confirm mira 0.9.0 and update before merging!

(2) Changing `python_requires = >=3.8` to `python_requires = >=3.9` on line 27 to avoid this error `Error: Version 3.8 with arch x64 not found` when Python 3.8 is unavailable