### PR TITLE
adding error messages and check for NaN values to compiled_dynamics

### DIFF
--- a/docs/source/sample_interface_solvers.ipynb
+++ b/docs/source/sample_interface_solvers.ipynb
@@ -361,22 +361,23 @@
     }
    ],
    "source": [
-    "start_t = time.time()\n",
-    "with pyro.poutine.seed(rng_seed=0):\n",
-    "    sample_results2 = pyciemss.sample(\n",
-    "        model,\n",
-    "        end_time,\n",
-    "        logging_step_size,\n",
-    "        num_samples,\n",
-    "        start_time=start_time,\n",
-    "        solver_method=\"explicit_adams\",\n",
-    "        solver_options={\"step_size\": 0.1},\n",
-    "    )\n",
-    "print(\"Time taken: \", time.time()-start_t)\n",
-    "# display(sample_results2[\"data\"])\n",
-    "# Plot results for all states\n",
-    "schema = plots.trajectories(sample_results2[\"data\"], keep=\"I_state\")\n",
-    "plots.ipy_display(schema, dpi=150)"
+    "if not smoke_test:\n",
+    "    start_t = time.time()\n",
+    "    with pyro.poutine.seed(rng_seed=0):\n",
+    "        sample_results2 = pyciemss.sample(\n",
+    "            model,\n",
+    "            end_time,\n",
+    "            logging_step_size,\n",
+    "            num_samples,\n",
+    "            start_time=start_time,\n",
+    "            solver_method=\"explicit_adams\",\n",
+    "            solver_options={\"step_size\": 0.1},\n",
+    "        )\n",
+    "    print(\"Time taken: \", time.time()-start_t)\n",
+    "    # display(sample_results2[\"data\"])\n",
+    "    # Plot results for all states\n",
+    "    schema = plots.trajectories(sample_results2[\"data\"], keep=\"I_state\")\n",
+    "    plots.ipy_display(schema, dpi=150)"
    ]
   },
   {
@@ -419,22 +420,23 @@
     }
    ],
    "source": [
-    "start_t = time.time()\n",
-    "with pyro.poutine.seed(rng_seed=0):\n",
-    "    sample_results2 = pyciemss.sample(\n",
-    "        model,\n",
-    "        end_time,\n",
-    "        logging_step_size,\n",
-    "        num_samples,\n",
-    "        start_time=start_time,\n",
-    "        solver_method=\"implicit_adams\",\n",
-    "        solver_options={\"step_size\": 0.1},\n",
-    "    )\n",
-    "print(\"Time taken: \", time.time()-start_t)\n",
-    "# display(sample_results2[\"data\"])\n",
-    "# Plot results for all states\n",
-    "schema = plots.trajectories(sample_results2[\"data\"], keep=\"I_state\")\n",
-    "plots.ipy_display(schema, dpi=150)"
+    "if not smoke_test:\n",
+    "    start_t = time.time()\n",
+    "    with pyro.poutine.seed(rng_seed=0):\n",
+    "        sample_results2 = pyciemss.sample(\n",
+    "            model,\n",
+    "            end_time,\n",
+    "            logging_step_size,\n",
+    "            num_samples,\n",
+    "            start_time=start_time,\n",
+    "            solver_method=\"implicit_adams\",\n",
+    "            solver_options={\"step_size\": 0.1},\n",
+    "        )\n",
+    "    print(\"Time taken: \", time.time()-start_t)\n",
+    "    # display(sample_results2[\"data\"])\n",
+    "    # Plot results for all states\n",
+    "    schema = plots.trajectories(sample_results2[\"data\"], keep=\"I_state\")\n",
+    "    plots.ipy_display(schema, dpi=150)"
    ]
   },
   {
@@ -554,7 +556,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -169,7 +169,9 @@ class CompiledDynamics(pyro.nn.PyroModule):
         for k, v in result.items():
             if torch.isnan(v).any():
                 raise ValueError(
-                    f"NaN value detected in '{k}'. This suggests an issue with the model configuration, please check your model equations, parameter values, initial conditions, and solver step size."
+                    f"""
+NaN value detected in '{k}'. This suggests an issue with the model configuration.
+Please check your model equations, parameter values, initial conditions, and solver step size."""
                 )
 
         return result

--- a/pyciemss/integration_utils/intervention_builder.py
+++ b/pyciemss/integration_utils/intervention_builder.py
@@ -217,7 +217,7 @@ def intervention_func_combinator(
 
 
 def combine_static_parameter_interventions(
-    interventions: List[Dict[float, Dict[str, Intervention]]]
+    interventions: List[Dict[float, Dict[str, Intervention]]],
 ) -> Dict[float, Dict[str, Intervention]]:
     """
     Combine a list of static parameter interventions into one.


### PR DESCRIPTION
Adds a descriptive error message when an `underflow` error is thrown by an adaptive step size solver, or infinite/NaN values are returned for states and/or observables. 

See https://github.com/ciemss/pyciemss/issues/643. 