### PR TITLE
Update compiled_dynamics.py

### DIFF
--- a/pyciemss/compiled_dynamics.py
+++ b/pyciemss/compiled_dynamics.py
@@ -131,7 +131,7 @@ class CompiledDynamics(pyro.nn.PyroModule):
                 state = simulate(self.deriv, self.initial_state(), start_time, end_time)
                 observables = self.observables(state)
         except AssertionError as e:
-            if "underflow in dt nan" in str(e):
+            if "underflow in dt" in str(e):
                 raise AssertionError(
                     "Underflow in the adaptive time step size. "
                     "This is likely due to a stiff system of ODEs. "


### PR DESCRIPTION
Removing the requirement that the string "nan" be included in the underflow error message. This error can also have the message "underflow in dt 0.0" or "underflow in dt {}" (per Tom's message on Slack).